### PR TITLE
Allow mintFee & free mints per user to be parameterized

### DIFF
--- a/contracts/BAP578.sol
+++ b/contracts/BAP578.sol
@@ -152,8 +152,7 @@ contract BAP578 is
             ? totalFreeMints - freeMintsClaimed[msg.sender]
             : 0;
 
-        if (freeMintsRemaining > 0) {
-            require(to == msg.sender, "Free mints can only be minted to self");
+        if (freeMintsRemaining > 0 && to == msg.sender) {
             isFreeMint[_tokenIdCounter + 1] = true;
             freeMintsClaimed[msg.sender]++;
         } else if (mintFee > 0) {


### PR DESCRIPTION
### Ticket

#### Summary of Changes

This is a simple quality of life improvement after participating in the abu dhabi hackathon, we realized that we had to somehow circumvent or make changes to the code, because some features like the `MINT_FEE` and `freeMintsPerUser` where hard coded.

It'd be a good idea to keep them as parameters so that there's flexibility with people who'd like to implement this codebase.

So the feedback from this PR comes from a real world implementation of this BAP

#### Notes

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

#### Checklist

- [ ] Added tests
- [x] Created showcase