### PR TITLE
feat: Add logicAddress allowlist security mechanism (SynthLaunch implementation)

### DIFF
--- a/contracts/community/NFAv2-SynthLaunch.sol
+++ b/contracts/community/NFAv2-SynthLaunch.sol
@@ -1,0 +1,466 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/**
+ * @title NFA v2 - Non-Fungible Agents
+ * @notice ERC-721 tokens representing AI agents with on-chain identity, funding, and evolution
+ * @dev BAP-578 compatible with logicAddress allowlist for security
+ *
+ * v2 Changes:
+ *  - Added logicAddress allowlist (approvedLogic mapping)
+ *  - setLogicAddress() now requires address to be approved (or address(0))
+ *  - Admin functions to manage allowlist
+ *  - Events for allowlist changes
+ */
+contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
+
+    // ============ Structs ============
+
+    struct Agent {
+        string name;           // Unique agent name (normalized)
+        address logic;         // Optional logic contract address (must be approved)
+        string persona;        // IPFS hash of persona data
+        string voice;          // IPFS hash of voice model
+        string animation;      // IPFS hash of animation/avatar
+        uint256 balance;       // Native token balance held by agent (internal accounting)
+        uint256 experience;    // XP for evolution tracking
+        uint256 level;         // Current level (derived from XP)
+        uint256 createdAt;     // Mint timestamp
+        bool active;           // Whether agent is active
+    }
+
+    // ============ State ============
+
+    mapping(uint256 => Agent) public agents;
+
+    // Name registry uses normalized (lowercase) name
+    mapping(string => bool) public nameExists;
+
+    // ============ Logic Allowlist (v2) ============
+    
+    /// @notice Approved logic contract addresses
+    mapping(address => bool) public approvedLogic;
+    
+    /// @notice List of all approved logic addresses (for enumeration)
+    address[] public approvedLogicList;
+
+    uint256 public totalMinted;
+    uint256 public maxSupply = 10000;
+    uint256 public mintPrice = 0.05 ether;
+    uint256 public constant XP_PER_LEVEL = 500;
+
+    // Platform fee settings
+    address public treasury;
+    uint256 public platformFeeBps = 250; // 2.5%
+
+    // ============ Events ============
+
+    event AgentMinted(uint256 indexed tokenId, address indexed owner, string name);
+    event AgentFunded(uint256 indexed tokenId, address indexed funder, uint256 amountNet, uint256 fee);
+    event AgentWithdraw(uint256 indexed tokenId, address indexed to, uint256 amount);
+    event AgentEvolved(uint256 indexed tokenId, uint256 xpGained, uint256 newLevel);
+    event AgentMetadataUpdated(uint256 indexed tokenId, string persona, string voice, string animation, string tokenURI);
+    event AgentLogicUpdated(uint256 indexed tokenId, address newLogic);
+    event AgentStatusChanged(uint256 indexed tokenId, bool active);
+    
+    // v2 events
+    event LogicApproved(address indexed logic, string reason);
+    event LogicRevoked(address indexed logic, string reason);
+
+    // ============ Errors ============
+
+    error NameTaken();
+    error NameEmpty();
+    error NameTooLong();
+    error NameInvalidChar();
+    error MaxSupplyReached();
+    error InsufficientPayment();
+    error NotAgentOwner();
+    error InsufficientAgentBalance();
+    error TransferFailed();
+    error InvalidTokenId();
+    error ZeroAmount();
+    error TreasuryZero();
+    error DirectReceiveDisabled();
+    error LogicNotApproved();      // v2
+    error LogicAlreadyApproved();  // v2
+    error LogicNotInList();        // v2
+    error ZeroAddressNotAllowed(); // v2
+    error AgentUsingRevokedLogic(); // v2
+
+    // ============ Constructor ============
+
+    constructor(address _treasury) ERC721("Non-Fungible Agent", "NFA") Ownable(msg.sender) {
+        if (_treasury == address(0)) revert TreasuryZero();
+        treasury = _treasury;
+    }
+
+    // ============ Logic Allowlist Management (v2) ============
+
+    /**
+     * @notice Approve a logic contract address
+     * @param logic Address to approve
+     * @param reason Audit reference or description
+     */
+    function approveLogic(address logic, string calldata reason) external onlyOwner {
+        if (logic == address(0)) revert ZeroAddressNotAllowed();
+        if (approvedLogic[logic]) revert LogicAlreadyApproved();
+        
+        approvedLogic[logic] = true;
+        approvedLogicList.push(logic);
+        
+        emit LogicApproved(logic, reason);
+    }
+
+    /**
+     * @notice Revoke approval for a logic contract
+     * @param logic Address to revoke
+     * @param reason Reason for revocation
+     */
+    function revokeLogic(address logic, string calldata reason) external onlyOwner {
+        if (!approvedLogic[logic]) revert LogicNotInList();
+        
+        approvedLogic[logic] = false;
+        
+        // Remove from list (swap and pop)
+        for (uint256 i = 0; i < approvedLogicList.length; i++) {
+            if (approvedLogicList[i] == logic) {
+                approvedLogicList[i] = approvedLogicList[approvedLogicList.length - 1];
+                approvedLogicList.pop();
+                break;
+            }
+        }
+        
+        emit LogicRevoked(logic, reason);
+    }
+
+    /**
+     * @notice Check if a logic address is approved
+     */
+    function isLogicApproved(address logic) external view returns (bool) {
+        return logic == address(0) || approvedLogic[logic];
+    }
+
+    /**
+     * @notice Get count of approved logic contracts
+     */
+    function approvedLogicCount() external view returns (uint256) {
+        return approvedLogicList.length;
+    }
+
+    /**
+     * @notice Get all approved logic addresses
+     */
+    function getApprovedLogicList() external view returns (address[] memory) {
+        return approvedLogicList;
+    }
+
+    // ============ Name Normalization ============
+
+    /// @notice Normalize a name to lowercase and validate charset: [a-z0-9_-], length 1..32
+    function _normalizeName(string calldata name) internal pure returns (string memory normalized) {
+        bytes calldata input = bytes(name);
+        uint256 len = input.length;
+        if (len == 0) revert NameEmpty();
+        if (len > 32) revert NameTooLong();
+
+        bytes memory out = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            uint8 c = uint8(input[i]);
+
+            // A-Z => a-z
+            if (c >= 65 && c <= 90) {
+                c = c + 32;
+            }
+
+            bool ok =
+                (c >= 97 && c <= 122) || // a-z
+                (c >= 48 && c <= 57) ||  // 0-9
+                (c == 95) ||             // _
+                (c == 45);               // -
+
+            if (!ok) revert NameInvalidChar();
+            out[i] = bytes1(c);
+        }
+        return string(out);
+    }
+
+    // ============ Minting ============
+
+    /**
+     * @notice Mint a new AI agent NFT
+     * @param name Unique name for the agent (will be normalized)
+     * @param persona IPFS hash of persona configuration
+     * @param voice IPFS hash of voice model (optional)
+     * @param animation IPFS hash of animation/avatar (optional)
+     * @param logic Address of logic contract (must be approved, or address(0) for none)
+     * @param _tokenURI Metadata URI for the NFT
+     */
+    function mintAgent(
+        string calldata name,
+        string calldata persona,
+        string calldata voice,
+        string calldata animation,
+        address logic,
+        string calldata _tokenURI
+    ) external payable nonReentrant returns (uint256) {
+        if (totalMinted >= maxSupply) revert MaxSupplyReached();
+        if (msg.value < mintPrice) revert InsufficientPayment();
+        
+        // v2: Check logic allowlist (address(0) always allowed)
+        if (logic != address(0) && !approvedLogic[logic]) revert LogicNotApproved();
+
+        string memory norm = _normalizeName(name);
+        if (nameExists[norm]) revert NameTaken();
+
+        uint256 tokenId = totalMinted;
+        totalMinted++;
+
+        // Mark name as taken
+        nameExists[norm] = true;
+
+        // Create agent
+        agents[tokenId] = Agent({
+            name: norm,
+            logic: logic,
+            persona: persona,
+            voice: voice,
+            animation: animation,
+            balance: 0,
+            experience: 0,
+            level: 1,
+            createdAt: block.timestamp,
+            active: true
+        });
+
+        // Mint NFT
+        _safeMint(msg.sender, tokenId);
+        _setTokenURI(tokenId, _tokenURI);
+
+        // Send mint fee to treasury
+        if (mintPrice > 0) {
+            (bool success, ) = treasury.call{value: mintPrice}("");
+            if (!success) revert TransferFailed();
+        }
+
+        // Refund excess
+        if (msg.value > mintPrice) {
+            (bool refundSuccess, ) = msg.sender.call{value: msg.value - mintPrice}("");
+            if (!refundSuccess) revert TransferFailed();
+        }
+
+        emit AgentMinted(tokenId, msg.sender, norm);
+        return tokenId;
+    }
+
+    // ============ Funding ============
+
+    /**
+     * @notice Fund an agent with native token (BNB on BSC)
+     * @param tokenId The agent token ID
+     */
+    function fundAgent(uint256 tokenId) external payable nonReentrant {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        if (msg.value == 0) revert ZeroAmount();
+
+        // Calculate platform fee
+        uint256 fee = (msg.value * platformFeeBps) / 10000;
+        uint256 netAmount = msg.value - fee;
+
+        // Add to agent balance
+        agents[tokenId].balance += netAmount;
+
+        // Send fee to treasury
+        if (fee > 0) {
+            (bool success, ) = treasury.call{value: fee}("");
+            if (!success) revert TransferFailed();
+        }
+
+        emit AgentFunded(tokenId, msg.sender, netAmount, fee);
+    }
+
+    /**
+     * @notice Withdraw native token from agent (owner only)
+     * @param tokenId The agent token ID
+     * @param amount Amount to withdraw
+     */
+    function withdrawFromAgent(uint256 tokenId, uint256 amount) external nonReentrant {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        if (ownerOf(tokenId) != msg.sender) revert NotAgentOwner();
+        if (amount == 0) revert ZeroAmount();
+        if (agents[tokenId].balance < amount) revert InsufficientAgentBalance();
+
+        agents[tokenId].balance -= amount;
+
+        (bool success, ) = msg.sender.call{value: amount}("");
+        if (!success) revert TransferFailed();
+
+        emit AgentWithdraw(tokenId, msg.sender, amount);
+    }
+
+    // ============ Evolution ============
+
+    /**
+     * @notice Add experience points to an agent (owner only)
+     * @param tokenId The agent token ID
+     * @param xp Experience points to add
+     */
+    function evolve(uint256 tokenId, uint256 xp) external {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        if (ownerOf(tokenId) != msg.sender) revert NotAgentOwner();
+        if (xp == 0) revert ZeroAmount();
+
+        Agent storage agent = agents[tokenId];
+        agent.experience += xp;
+
+        // Calculate new level
+        uint256 newLevel = (agent.experience / XP_PER_LEVEL) + 1;
+        agent.level = newLevel;
+
+        emit AgentEvolved(tokenId, xp, newLevel);
+    }
+
+    // ============ Metadata Updates ============
+
+    /**
+     * @notice Update agent metadata (owner only)
+     */
+    function updateMetadata(
+        uint256 tokenId,
+        string calldata persona,
+        string calldata voice,
+        string calldata animation,
+        string calldata _tokenURI
+    ) external {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        if (ownerOf(tokenId) != msg.sender) revert NotAgentOwner();
+
+        Agent storage agent = agents[tokenId];
+
+        if (bytes(persona).length > 0) agent.persona = persona;
+        if (bytes(voice).length > 0) agent.voice = voice;
+        if (bytes(animation).length > 0) agent.animation = animation;
+
+        if (bytes(_tokenURI).length > 0) {
+            _setTokenURI(tokenId, _tokenURI);
+        }
+
+        emit AgentMetadataUpdated(tokenId, agent.persona, agent.voice, agent.animation, tokenURI(tokenId));
+    }
+
+    /**
+     * @notice Set logic contract address (owner only, must be approved)
+     * @dev address(0) is always allowed (disables logic)
+     */
+    function setLogicAddress(uint256 tokenId, address logic) external {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        if (ownerOf(tokenId) != msg.sender) revert NotAgentOwner();
+        
+        // v2: Check allowlist (address(0) always allowed to disable)
+        if (logic != address(0) && !approvedLogic[logic]) revert LogicNotApproved();
+        
+        agents[tokenId].logic = logic;
+        emit AgentLogicUpdated(tokenId, logic);
+    }
+
+    /**
+     * @notice Toggle agent active status (owner only)
+     */
+    function setActive(uint256 tokenId, bool active) external {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        if (ownerOf(tokenId) != msg.sender) revert NotAgentOwner();
+        agents[tokenId].active = active;
+        emit AgentStatusChanged(tokenId, active);
+    }
+
+    // ============ View Functions ============
+
+    /**
+     * @notice Get full agent details
+     */
+    function getAgentDetails(uint256 tokenId) external view returns (
+        string memory name,
+        address logic,
+        string memory persona,
+        string memory voice,
+        string memory animation,
+        uint256 balance,
+        uint256 experience,
+        uint256 level,
+        uint256 createdAt,
+        bool active
+    ) {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        Agent storage agent = agents[tokenId];
+        return (
+            agent.name,
+            agent.logic,
+            agent.persona,
+            agent.voice,
+            agent.animation,
+            agent.balance,
+            agent.experience,
+            agent.level,
+            agent.createdAt,
+            agent.active
+        );
+    }
+
+    // ============ Admin Functions ============
+
+    function setMintPrice(uint256 _price) external onlyOwner {
+        mintPrice = _price;
+    }
+
+    function setMaxSupply(uint256 _maxSupply) external onlyOwner {
+        require(_maxSupply >= totalMinted, "Below minted");
+        maxSupply = _maxSupply;
+    }
+
+    function setTreasury(address _treasury) external onlyOwner {
+        if (_treasury == address(0)) revert TreasuryZero();
+        treasury = _treasury;
+    }
+
+    function setPlatformFeeBps(uint256 _feeBps) external onlyOwner {
+        require(_feeBps <= 1000, "Max 10%");
+        platformFeeBps = _feeBps;
+    }
+
+    /**
+     * @notice Force reset logic for an agent (admin emergency)
+     * @dev Use when a logic contract is revoked but agents still reference it
+     */
+    function forceResetLogic(uint256 tokenId, string calldata reason) external onlyOwner {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        agents[tokenId].logic = address(0);
+        emit AgentLogicUpdated(tokenId, address(0));
+        emit LogicRevoked(agents[tokenId].logic, reason);
+    }
+
+    /// @notice Disable renounceOwnership to prevent locking allowlist
+    function renounceOwnership() public pure override {
+        revert("Disabled");
+    }
+
+    // ============ Overrides ============
+
+    function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
+        return super.tokenURI(tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721, ERC721URIStorage) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    // ============ Receive ============
+
+    receive() external payable {
+        revert DirectReceiveDisabled();
+    }
+}

--- a/contracts/community/NFAv2-SynthLaunch.sol
+++ b/contracts/community/NFAv2-SynthLaunch.sol
@@ -104,12 +104,13 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
 
     /**
      * @notice Approve a logic contract address
-     * @param logic Address to approve
+     * @param logic Address to approve (must be a contract, not EOA)
      * @param reason Audit reference or description
      */
     function approveLogic(address logic, string calldata reason) external onlyOwner {
         if (logic == address(0)) revert ZeroAddressNotAllowed();
         if (approvedLogic[logic]) revert LogicAlreadyApproved();
+        require(logic.code.length > 0, "Logic must be a contract");
         
         approvedLogic[logic] = true;
         approvedLogicList.push(logic);
@@ -121,6 +122,9 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
      * @notice Revoke approval for a logic contract
      * @param logic Address to revoke
      * @param reason Reason for revocation
+     * @dev After revocation, agents using this logic will be blocked from
+     *      operating until their logic is reset via forceResetLogic() or
+     *      the owner sets a new approved logic via setLogicAddress().
      */
     function revokeLogic(address logic, string calldata reason) external onlyOwner {
         if (!approvedLogic[logic]) revert LogicNotInList();
@@ -137,6 +141,25 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
         }
         
         emit LogicRevoked(logic, reason);
+    }
+
+    /**
+     * @notice Check if an agent's current logic is still valid
+     * @dev Returns false if the agent's logic was revoked after assignment
+     */
+    function isAgentLogicValid(uint256 tokenId) public view returns (bool) {
+        if (tokenId >= totalMinted) revert InvalidTokenId();
+        address logic = agents[tokenId].logic;
+        return logic == address(0) || approvedLogic[logic];
+    }
+
+    /**
+     * @notice Modifier to ensure agent's logic is still approved
+     * @dev Reverts with AgentUsingRevokedLogic if logic was revoked
+     */
+    modifier validAgentLogic(uint256 tokenId) {
+        if (!isAgentLogicValid(tokenId)) revert AgentUsingRevokedLogic();
+        _;
     }
 
     /**
@@ -264,7 +287,7 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
      * @notice Fund an agent with native token (BNB on BSC)
      * @param tokenId The agent token ID
      */
-    function fundAgent(uint256 tokenId) external payable nonReentrant {
+    function fundAgent(uint256 tokenId) external payable nonReentrant validAgentLogic(tokenId) {
         if (tokenId >= totalMinted) revert InvalidTokenId();
         if (msg.value == 0) revert ZeroAmount();
 
@@ -310,7 +333,7 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
      * @param tokenId The agent token ID
      * @param xp Experience points to add
      */
-    function evolve(uint256 tokenId, uint256 xp) external {
+    function evolve(uint256 tokenId, uint256 xp) external validAgentLogic(tokenId) {
         if (tokenId >= totalMinted) revert InvalidTokenId();
         if (ownerOf(tokenId) != msg.sender) revert NotAgentOwner();
         if (xp == 0) revert ZeroAmount();
@@ -438,9 +461,10 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
      */
     function forceResetLogic(uint256 tokenId, string calldata reason) external onlyOwner {
         if (tokenId >= totalMinted) revert InvalidTokenId();
+        address oldLogic = agents[tokenId].logic;
         agents[tokenId].logic = address(0);
         emit AgentLogicUpdated(tokenId, address(0));
-        emit LogicRevoked(agents[tokenId].logic, reason);
+        emit LogicRevoked(oldLogic, reason);
     }
 
     /// @notice Disable renounceOwnership to prevent locking allowlist

--- a/contracts/community/NFAv2-SynthLaunch.sol
+++ b/contracts/community/NFAv2-SynthLaunch.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /**
  * @title NFA v2 - Non-Fungible Agents
@@ -95,7 +95,7 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
 
     // ============ Constructor ============
 
-    constructor(address _treasury) ERC721("Non-Fungible Agent", "NFA") Ownable(msg.sender) {
+    constructor(address _treasury) ERC721("Non-Fungible Agent", "NFA") {
         if (_treasury == address(0)) revert TreasuryZero();
         treasury = _treasury;
     }
@@ -473,6 +473,10 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
     }
 
     // ============ Overrides ============
+
+    function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
+        super._burn(tokenId);
+    }
 
     function tokenURI(uint256 tokenId) public view override(ERC721, ERC721URIStorage) returns (string memory) {
         return super.tokenURI(tokenId);

--- a/contracts/community/NFAv2-SynthLaunch.sol
+++ b/contracts/community/NFAv2-SynthLaunch.sol
@@ -71,6 +71,12 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
     // v2 events
     event LogicApproved(address indexed logic, string reason);
     event LogicRevoked(address indexed logic, string reason);
+    /// @notice Emitted when an admin force-resets a single agent's logic back
+    ///         to address(0). Distinct from LogicRevoked so off-chain indexers
+    ///         can reconstruct the global allowlist purely from
+    ///         LogicApproved / LogicRevoked without being confused by
+    ///         per-agent resets that do not touch approvedLogic.
+    event AgentLogicForceReset(uint256 indexed tokenId, address indexed oldLogic, string reason);
 
     // ============ Errors ============
 
@@ -456,15 +462,20 @@ contract NFAv2 is ERC721, ERC721URIStorage, Ownable, ReentrancyGuard {
     }
 
     /**
-     * @notice Force reset logic for an agent (admin emergency)
-     * @dev Use when a logic contract is revoked but agents still reference it
+     * @notice Force reset a single agent's logic back to address(0) (admin emergency)
+     * @dev Use when a logic contract is compromised but agents still reference it,
+     *      or the agent's owner is unresponsive. This does NOT modify the global
+     *      allowlist — `approvedLogic[oldLogic]` is untouched. To remove a logic
+     *      from the allowlist use `revokeLogic` instead. Emits
+     *      `AgentLogicForceReset` (not `LogicRevoked`) so off-chain indexers can
+     *      distinguish per-agent resets from global allowlist revocations.
      */
     function forceResetLogic(uint256 tokenId, string calldata reason) external onlyOwner {
         if (tokenId >= totalMinted) revert InvalidTokenId();
         address oldLogic = agents[tokenId].logic;
         agents[tokenId].logic = address(0);
         emit AgentLogicUpdated(tokenId, address(0));
-        emit LogicRevoked(oldLogic, reason);
+        emit AgentLogicForceReset(tokenId, oldLogic, reason);
     }
 
     /// @notice Disable renounceOwnership to prevent locking allowlist

--- a/test/NFAv2-SynthLaunch.test.js
+++ b/test/NFAv2-SynthLaunch.test.js
@@ -1,0 +1,351 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('NFAv2 (SynthLaunch community implementation)', function () {
+  let nfa;
+  let approvedLogic;
+  let secondLogic;
+  let owner;
+  let user1;
+  let user2;
+  let treasury;
+
+  const MINT_PRICE = ethers.utils.parseEther('0.05');
+
+  beforeEach(async function () {
+    [owner, user1, user2, treasury] = await ethers.getSigners();
+
+    const NFAv2 = await ethers.getContractFactory('NFAv2');
+    nfa = await NFAv2.deploy(treasury.address);
+    await nfa.deployed();
+
+    // Deploy two disposable contracts to use as "logic" addresses
+    // (any deployed contract with code is fine for approveLogic's bytecode check)
+    const FakeLogic = await ethers.getContractFactory('NFAv2');
+    approvedLogic = await FakeLogic.deploy(treasury.address);
+    await approvedLogic.deployed();
+    secondLogic = await FakeLogic.deploy(treasury.address);
+    await secondLogic.deployed();
+  });
+
+  // ============ Deployment ============
+  describe('Deployment', function () {
+    it('sets the correct name and symbol', async function () {
+      expect(await nfa.name()).to.equal('Non-Fungible Agent');
+      expect(await nfa.symbol()).to.equal('NFA');
+    });
+
+    it('sets the deployer as owner', async function () {
+      expect(await nfa.owner()).to.equal(owner.address);
+    });
+
+    it('sets the correct treasury', async function () {
+      expect(await nfa.treasury()).to.equal(treasury.address);
+    });
+
+    it('reverts when treasury is zero address', async function () {
+      const NFAv2 = await ethers.getContractFactory('NFAv2');
+      await expect(NFAv2.deploy(ethers.constants.AddressZero)).to.be.revertedWithCustomError(
+        nfa,
+        'TreasuryZero'
+      );
+    });
+  });
+
+  // ============ Logic Allowlist (admin) ============
+  describe('Logic Allowlist — admin', function () {
+    it('owner can approve a contract address', async function () {
+      await expect(nfa.approveLogic(approvedLogic.address, 'audit-ref-1'))
+        .to.emit(nfa, 'LogicApproved')
+        .withArgs(approvedLogic.address, 'audit-ref-1');
+
+      expect(await nfa.approvedLogic(approvedLogic.address)).to.equal(true);
+      expect(await nfa.approvedLogicCount()).to.equal(1);
+    });
+
+    it('rejects zero address', async function () {
+      await expect(
+        nfa.approveLogic(ethers.constants.AddressZero, 'x')
+      ).to.be.revertedWithCustomError(nfa, 'ZeroAddressNotAllowed');
+    });
+
+    it('rejects EOA (no bytecode)', async function () {
+      await expect(nfa.approveLogic(user1.address, 'x')).to.be.revertedWith('Logic must be a contract');
+    });
+
+    it('rejects double-approve of same address', async function () {
+      await nfa.approveLogic(approvedLogic.address, 'r1');
+      await expect(
+        nfa.approveLogic(approvedLogic.address, 'r2')
+      ).to.be.revertedWithCustomError(nfa, 'LogicAlreadyApproved');
+    });
+
+    it('non-owner cannot approve', async function () {
+      await expect(
+        nfa.connect(user1).approveLogic(approvedLogic.address, 'x')
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('owner can revoke an approved logic', async function () {
+      await nfa.approveLogic(approvedLogic.address, 'r1');
+
+      await expect(nfa.revokeLogic(approvedLogic.address, 'compromised'))
+        .to.emit(nfa, 'LogicRevoked')
+        .withArgs(approvedLogic.address, 'compromised');
+
+      expect(await nfa.approvedLogic(approvedLogic.address)).to.equal(false);
+      expect(await nfa.approvedLogicCount()).to.equal(0);
+    });
+
+    it('revoke removes address from list (swap-and-pop)', async function () {
+      await nfa.approveLogic(approvedLogic.address, 'a');
+      await nfa.approveLogic(secondLogic.address, 'b');
+      expect(await nfa.approvedLogicCount()).to.equal(2);
+
+      await nfa.revokeLogic(approvedLogic.address, 'x');
+
+      expect(await nfa.approvedLogicCount()).to.equal(1);
+      const list = await nfa.getApprovedLogicList();
+      expect(list).to.have.lengthOf(1);
+      expect(list[0]).to.equal(secondLogic.address);
+    });
+
+    it('rejects revoke of non-approved address', async function () {
+      await expect(
+        nfa.revokeLogic(approvedLogic.address, 'x')
+      ).to.be.revertedWithCustomError(nfa, 'LogicNotInList');
+    });
+
+    it('isLogicApproved returns true for zero address (disabled state)', async function () {
+      expect(await nfa.isLogicApproved(ethers.constants.AddressZero)).to.equal(true);
+    });
+  });
+
+  // ============ Minting ============
+  describe('Minting', function () {
+    it('mints with address(0) logic (no logic attached)', async function () {
+      await expect(
+        nfa
+          .connect(user1)
+          .mintAgent('alice', 'ipfs://p', 'ipfs://v', 'ipfs://a', ethers.constants.AddressZero, 'ipfs://meta', {
+            value: MINT_PRICE,
+          })
+      ).to.emit(nfa, 'AgentMinted');
+
+      expect(await nfa.totalMinted()).to.equal(1);
+      expect(await nfa.ownerOf(0)).to.equal(user1.address);
+    });
+
+    it('mints with an approved logic address', async function () {
+      await nfa.approveLogic(approvedLogic.address, 'audit-1');
+
+      await nfa
+        .connect(user1)
+        .mintAgent('bob', 'ipfs://p', 'ipfs://v', 'ipfs://a', approvedLogic.address, 'ipfs://meta', {
+          value: MINT_PRICE,
+        });
+
+      const [, logic] = await nfa.getAgentDetails(0);
+      expect(logic).to.equal(approvedLogic.address);
+    });
+
+    it('reverts when minting with a non-approved logic address', async function () {
+      await expect(
+        nfa
+          .connect(user1)
+          .mintAgent('carol', 'ipfs://p', 'ipfs://v', 'ipfs://a', approvedLogic.address, 'ipfs://meta', {
+            value: MINT_PRICE,
+          })
+      ).to.be.revertedWithCustomError(nfa, 'LogicNotApproved');
+    });
+
+    it('reverts when underpaid', async function () {
+      await expect(
+        nfa
+          .connect(user1)
+          .mintAgent('dave', 'ipfs://p', 'ipfs://v', 'ipfs://a', ethers.constants.AddressZero, 'ipfs://meta', {
+            value: ethers.utils.parseEther('0.01'),
+          })
+      ).to.be.revertedWithCustomError(nfa, 'InsufficientPayment');
+    });
+
+    it('rejects duplicate normalized names', async function () {
+      await nfa
+        .connect(user1)
+        .mintAgent('Alice', 'p', 'v', 'a', ethers.constants.AddressZero, 'm', { value: MINT_PRICE });
+      await expect(
+        nfa
+          .connect(user2)
+          .mintAgent('ALICE', 'p', 'v', 'a', ethers.constants.AddressZero, 'm', { value: MINT_PRICE })
+      ).to.be.revertedWithCustomError(nfa, 'NameTaken');
+    });
+
+    it('refunds excess payment and sends only MINT_PRICE to treasury', async function () {
+      const excess = ethers.utils.parseEther('0.02');
+      const treasuryBefore = await ethers.provider.getBalance(treasury.address);
+      await nfa
+        .connect(user1)
+        .mintAgent('eve', 'p', 'v', 'a', ethers.constants.AddressZero, 'm', {
+          value: MINT_PRICE.add(excess),
+        });
+      const treasuryAfter = await ethers.provider.getBalance(treasury.address);
+      // Treasury receives exactly MINT_PRICE (excess refunded to caller)
+      expect(treasuryAfter.sub(treasuryBefore)).to.equal(MINT_PRICE);
+      // Contract should hold nothing
+      expect(await ethers.provider.getBalance(nfa.address)).to.equal(0);
+    });
+  });
+
+  // ============ setLogicAddress ============
+  describe('setLogicAddress', function () {
+    beforeEach(async function () {
+      await nfa.approveLogic(approvedLogic.address, 'audit-1');
+      await nfa
+        .connect(user1)
+        .mintAgent('alpha', 'p', 'v', 'a', ethers.constants.AddressZero, 'm', { value: MINT_PRICE });
+    });
+
+    it('owner can set approved logic', async function () {
+      await expect(nfa.connect(user1).setLogicAddress(0, approvedLogic.address))
+        .to.emit(nfa, 'AgentLogicUpdated')
+        .withArgs(0, approvedLogic.address);
+    });
+
+    it('owner can clear logic by passing address(0)', async function () {
+      await nfa.connect(user1).setLogicAddress(0, approvedLogic.address);
+      await nfa.connect(user1).setLogicAddress(0, ethers.constants.AddressZero);
+      const [, logic] = await nfa.getAgentDetails(0);
+      expect(logic).to.equal(ethers.constants.AddressZero);
+    });
+
+    it('reverts when setting non-approved logic', async function () {
+      await expect(
+        nfa.connect(user1).setLogicAddress(0, secondLogic.address)
+      ).to.be.revertedWithCustomError(nfa, 'LogicNotApproved');
+    });
+
+    it('only agent owner can setLogicAddress', async function () {
+      await expect(
+        nfa.connect(user2).setLogicAddress(0, approvedLogic.address)
+      ).to.be.revertedWithCustomError(nfa, 'NotAgentOwner');
+    });
+  });
+
+  // ============ Revocation + validAgentLogic modifier ============
+  describe('Logic revocation propagation', function () {
+    beforeEach(async function () {
+      await nfa.approveLogic(approvedLogic.address, 'audit-1');
+      await nfa
+        .connect(user1)
+        .mintAgent('beta', 'p', 'v', 'a', approvedLogic.address, 'm', { value: MINT_PRICE });
+    });
+
+    it('agent is valid while its logic is approved', async function () {
+      expect(await nfa.isAgentLogicValid(0)).to.equal(true);
+    });
+
+    it('agent becomes invalid once logic is revoked', async function () {
+      await nfa.revokeLogic(approvedLogic.address, 'compromised');
+      expect(await nfa.isAgentLogicValid(0)).to.equal(false);
+    });
+
+    it('fundAgent reverts when agent is using revoked logic', async function () {
+      await nfa.revokeLogic(approvedLogic.address, 'compromised');
+      await expect(
+        nfa.connect(user2).fundAgent(0, { value: ethers.utils.parseEther('0.1') })
+      ).to.be.revertedWithCustomError(nfa, 'AgentUsingRevokedLogic');
+    });
+
+    it('evolve reverts when agent is using revoked logic', async function () {
+      await nfa.revokeLogic(approvedLogic.address, 'compromised');
+      await expect(nfa.connect(user1).evolve(0, 100)).to.be.revertedWithCustomError(
+        nfa,
+        'AgentUsingRevokedLogic'
+      );
+    });
+
+    it('agent recovers when owner sets a new approved logic', async function () {
+      await nfa.revokeLogic(approvedLogic.address, 'compromised');
+      await nfa.approveLogic(secondLogic.address, 'audit-2');
+      await nfa.connect(user1).setLogicAddress(0, secondLogic.address);
+      expect(await nfa.isAgentLogicValid(0)).to.equal(true);
+    });
+
+    it('agent recovers when owner clears logic to address(0)', async function () {
+      await nfa.revokeLogic(approvedLogic.address, 'compromised');
+      await nfa.connect(user1).setLogicAddress(0, ethers.constants.AddressZero);
+      expect(await nfa.isAgentLogicValid(0)).to.equal(true);
+    });
+  });
+
+  // ============ forceResetLogic ============
+  describe('forceResetLogic (admin emergency)', function () {
+    beforeEach(async function () {
+      await nfa.approveLogic(approvedLogic.address, 'audit-1');
+      await nfa
+        .connect(user1)
+        .mintAgent('gamma', 'p', 'v', 'a', approvedLogic.address, 'm', { value: MINT_PRICE });
+    });
+
+    it('emits LogicRevoked with the OLD logic address (Greptile fix #1)', async function () {
+      // Prior to Greptile fix, this event emitted address(0) because
+      // agents[tokenId].logic was cleared BEFORE the event. The fix caches
+      // oldLogic first, so the event now carries the real pre-reset address.
+      await expect(nfa.forceResetLogic(0, 'emergency'))
+        .to.emit(nfa, 'LogicRevoked')
+        .withArgs(approvedLogic.address, 'emergency');
+    });
+
+    it('also emits AgentLogicUpdated to address(0)', async function () {
+      await expect(nfa.forceResetLogic(0, 'emergency'))
+        .to.emit(nfa, 'AgentLogicUpdated')
+        .withArgs(0, ethers.constants.AddressZero);
+    });
+
+    it('only owner can forceResetLogic', async function () {
+      await expect(nfa.connect(user1).forceResetLogic(0, 'x')).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      );
+    });
+  });
+
+  // ============ Funding / evolution (happy path sanity) ============
+  describe('Funding & evolution (happy path)', function () {
+    beforeEach(async function () {
+      await nfa
+        .connect(user1)
+        .mintAgent('fund', 'p', 'v', 'a', ethers.constants.AddressZero, 'm', { value: MINT_PRICE });
+    });
+
+    it('fundAgent deducts platform fee and credits the rest to agent balance', async function () {
+      const amount = ethers.utils.parseEther('1');
+      const feeBps = await nfa.platformFeeBps();
+      const fee = amount.mul(feeBps).div(10000);
+      const net = amount.sub(fee);
+
+      await nfa.connect(user2).fundAgent(0, { value: amount });
+      const [, , , , , balance] = await nfa.getAgentDetails(0);
+      expect(balance).to.equal(net);
+    });
+
+    it('evolve raises level when XP crosses XP_PER_LEVEL', async function () {
+      await nfa.connect(user1).evolve(0, 500);
+      const [, , , , , , xp, level] = await nfa.getAgentDetails(0);
+      expect(xp).to.equal(500);
+      expect(level).to.equal(2);
+    });
+  });
+
+  // ============ Ownership / safety ============
+  describe('Ownership safety', function () {
+    it('renounceOwnership is disabled', async function () {
+      await expect(nfa.renounceOwnership()).to.be.revertedWith('Disabled');
+    });
+
+    it('direct ETH transfer is rejected', async function () {
+      await expect(
+        user1.sendTransaction({ to: nfa.address, value: ethers.utils.parseEther('0.1') })
+      ).to.be.revertedWithCustomError(nfa, 'DirectReceiveDisabled');
+    });
+  });
+});

--- a/test/NFAv2-SynthLaunch.test.js
+++ b/test/NFAv2-SynthLaunch.test.js
@@ -287,13 +287,31 @@ describe('NFAv2 (SynthLaunch community implementation)', function () {
         .mintAgent('gamma', 'p', 'v', 'a', approvedLogic.address, 'm', { value: MINT_PRICE });
     });
 
-    it('emits LogicRevoked with the OLD logic address (Greptile fix #1)', async function () {
-      // Prior to Greptile fix, this event emitted address(0) because
-      // agents[tokenId].logic was cleared BEFORE the event. The fix caches
-      // oldLogic first, so the event now carries the real pre-reset address.
+    it('emits AgentLogicForceReset with tokenId + old logic + reason', async function () {
+      // This emits the dedicated per-agent reset event, not LogicRevoked.
+      // Indexers can rebuild the global allowlist from LogicApproved/LogicRevoked
+      // alone without being misled by agent-level resets.
       await expect(nfa.forceResetLogic(0, 'emergency'))
-        .to.emit(nfa, 'LogicRevoked')
-        .withArgs(approvedLogic.address, 'emergency');
+        .to.emit(nfa, 'AgentLogicForceReset')
+        .withArgs(0, approvedLogic.address, 'emergency');
+    });
+
+    it('does NOT emit LogicRevoked (that event is reserved for global allowlist changes)', async function () {
+      await expect(nfa.forceResetLogic(0, 'emergency')).to.not.emit(nfa, 'LogicRevoked');
+    });
+
+    it('leaves the global allowlist untouched — approvedLogic[oldLogic] stays true', async function () {
+      // This is the key invariant the P1 fix guarantees. A force-reset of one
+      // agent must not implicitly remove the logic from the global allowlist,
+      // otherwise re-approveLogic would revert with LogicAlreadyApproved despite
+      // indexers believing it was revoked.
+      expect(await nfa.approvedLogic(approvedLogic.address)).to.equal(true);
+      await nfa.forceResetLogic(0, 'emergency');
+      expect(await nfa.approvedLogic(approvedLogic.address)).to.equal(true);
+      // Re-approving would fail if the allowlist were implicitly touched:
+      await expect(
+        nfa.approveLogic(approvedLogic.address, 're-approve attempt')
+      ).to.be.revertedWithCustomError(nfa, 'LogicAlreadyApproved');
     });
 
     it('also emits AgentLogicUpdated to address(0)', async function () {


### PR DESCRIPTION
## Summary

This PR adds a secure `logicAddress` management mechanism through an allowlist pattern, addressing the security concern raised by @ladyxtel regarding governance for upgradeable logic contracts.

## Changes

Added `contracts/community/NFAv2-SynthLaunch.sol` - an enhanced NFA implementation with:

### 1. logicAddress Allowlist ✅
- `approvedLogic` mapping to whitelist audited logic contracts
- `setLogicAddress()` now requires address to be approved (or `address(0)`)
- Prevents owners from binding malicious unaudited contracts

### 2. Admin Controls
- `approveLogic(address, reason)` - Add to whitelist with audit reference
- `revokeLogic(address, reason)` - Remove from whitelist  
- `forceResetLogic(tokenId, reason)` - Emergency reset for compromised agents
- `renounceOwnership()` disabled - Prevents locking the allowlist

### 3. Key Security Features
- `address(0)` always allowed (disable logic)
- Events for all allowlist changes (audit trail)
- Backward compatible with existing NFA interface

## Deployed & Verified

- **BSC Mainnet**: [0x2b703D4dC84ACB24a0A3F34CBF259D5Cb2B62b19](https://bscscan.com/address/0x2b703D4dC84ACB24a0A3F34CBF259D5Cb2B62b19#code)
- **Frontend**: https://synthlaunch.fun/nfa

## Related Discussion

This addresses the logicAddress governance concern regarding registry/allowlist for upgradeable logic without introducing rug/attack surface.

---

*SynthLaunch - AI Agent Launchpad on BSC*