### PR TITLE
feat: Add Policy Validation Framework (BAP-578 Section 4.7 Security E…

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,146 @@
+# Security: Policy Validation Framework for BAP-578
+
+> Contributed by [SHLL Protocol](https://github.com/shll-protocol/shll)
+
+## Overview
+
+This document describes the security architecture for policy-enforced AI agent actions on BAP-578 NFA tokens. The framework extends BAP-578 §4.7 (Security Mechanisms) with **granular, on-chain, per-transaction policy enforcement**.
+
+## Threat Model
+
+AI agents operating autonomously on-chain face attack vectors that traditional Web3 security does not address:
+
+| Threat | Description | Impact |
+|---|---|---|
+| **Model Hallucination** | LLM generates incorrect parameters (wrong token address, extreme slippage, excessive amounts) | Irreversible loss of funds |
+| **Prompt Injection** | Malicious data sources trick the agent into executing unauthorized transfers | Funds redirected to attacker |
+| **Supply Chain Attack** | Compromised npm/pip dependency alters transaction payloads before signing | Silent fund theft |
+| **Operator Key Compromise** | Attacker gains access to the AI agent's execution key | Full access to agent funds |
+
+**Key insight**: All four attack vectors originate in the off-chain environment (LLM, runtime, dependencies). The only defense that cannot be bypassed is **on-chain smart contract enforcement**.
+
+## Four Core Policies
+
+The PolicyGuard framework defines **four core policy types**. Each policy validates a single aspect of an action:
+
+| Layer | Policy Type | What It Blocks | Fail-Close Behavior |
+|---|---|---|---|
+| 1 | **SpendingLimit** | Transactions exceeding per-action or daily caps; also integrates token whitelist + approve control in production V2 | No limit configured → block |
+| 2 | **Cooldown** | Rapid-fire transactions (bot loops, gas drain) | Cooldown not elapsed → block |
+| 3 | **DeFiGuard** | Calls to non-approved contracts or function selectors; subsumes DEX router whitelisting | Unknown target/selector → block |
+| 4 | **ReceiverGuard** | Transfers to non-whitelisted addresses | No whitelist → block |
+
+> **Design note**: Earlier iterations included separate `DexWhitelist` and `TokenWhitelist` policies. These were consolidated — `DeFiGuard` subsumes DEX router whitelisting (target + selector), and `SpendingLimitV2` integrates token whitelist + approve control. Four policies provide complete coverage with less administrative overhead.
+
+### Fail-Close Design
+
+All policies follow **fail-close** semantics:
+- If a policy contract reverts → action is **BLOCKED**
+- If a policy returns `ok=false` → action is **BLOCKED**
+- If no policies are bound → action is **BLOCKED**
+- Only explicit `ok=true` from **ALL** bound policies permits execution
+
+There is no "default allow." The system fails safe, always.
+
+## Security Architecture: Dual-Wallet Model
+
+```
+┌─────────────────────────────┐
+│         Owner Wallet        │  ← User-controlled
+│  • Holds NFA token          │  • Sets policies
+│  • Full admin rights        │  • Withdraws funds
+│  • Cannot be overridden     │  • Pauses agent
+└────────────┬────────────────┘
+             │ owns
+┌────────────▼────────────────┐
+│       AgentAccount          │  ← Smart contract vault
+│  • Isolated fund storage    │     (ERC-6551 TBA)
+│  • PolicyGuard enforced     │
+│  • All actions validated    │
+└────────────┬────────────────┘
+             │ executes through
+┌────────────▼────────────────┐
+│      Operator Wallet        │  ← AI-controlled
+│  • Can only propose actions │  • Cannot transfer funds out
+│  • Cannot modify policies   │  • Cannot self-destruct
+│  • Subject to ALL policies  │  • Cannot bypass PolicyGuard
+└─────────────────────────────┘
+```
+
+**Key property**: The AI agent (operator) can only propose actions. The smart contract (PolicyGuard) decides whether to execute them. Even if the operator key is fully compromised, the attacker is still bound by all on-chain policies.
+
+## Security Checklist
+
+### Smart Contract Security
+
+- [x] **Reentrancy protection** — All state changes before external calls (CEI pattern)
+- [x] **Access control** — Owner-only administrative functions
+- [x] **Input validation** — Zero-address checks, array bounds
+- [x] **Fail-close by default** — Unconfigured agents cannot execute actions
+- [x] **No delegatecall** — Policies cannot execute arbitrary code
+- [x] **View-only validation** — `validate()` is `view`, cannot modify state during check
+- [x] **Composable isolation** — Each policy is an independent contract
+
+### Known Limitations (Resolved)
+
+> **SpendingLimitPolicyV2: Daily Cap (`maxPerDay`) — FIXED**
+>
+> **Severity**: Medium | **Status**: ✅ Fixed
+>
+> **Previous issue**: The `onCommit()` function only tracked `msg.value` (native BNB) toward the daily cap. For ERC20→ERC20 swaps using `approve` + `swap` flow, `value=0` bypassed daily accumulation.
+>
+> **Fix**: Added `_extractSpendAmount()` helper that parses `amountIn` from swap calldata using the existing `OutputPattern` registry. Both `check()` and `onCommit()` now enforce daily caps against native BNB **and** ERC20 swap amounts. Supports V2 5-param, V3 single, and V3 multi swap layouts.
+>
+> **Test coverage**: 54/54 SpendingLimit tests pass including 2 new ERC20 swap daily limit test cases. Full suite: 278/278 tests pass.
+>
+> **Design note**: `amountIn` for ERC20 swaps is in token-native denomination, not BNB. The daily cap serves as a velocity limiter rather than an exact BNB-equivalent budget. Combined with `CooldownPolicy`, this provides effective rate limiting.
+
+### Operational Security
+
+- [x] **Owner/Operator separation** — AI never holds the ownership key
+- [x] **On-chain enforcement** — All policies enforced at smart contract level
+- [x] **Auditable trail** — Events emitted for every validation and execution
+- [x] **Emergency controls** — Agent can be paused via state toggle
+
+## Production Deployment (BSC Mainnet)
+
+SHLL Protocol maintains the production reference implementation with **12 verified contracts** on BSC Mainnet (Chain ID: 56):
+
+| Contract | Address | Purpose |
+|---|---|---|
+| AgentNFA (V4.1) | [`0x71cE46099E4b2a2434111C009A7E9CFd69747c8E`](https://bscscan.com/address/0x71cE46099E4b2a2434111C009A7E9CFd69747c8E) | BAP-578 core: agent identity & lifecycle |
+| PolicyGuardV4 | [`0x25d17eA0e3Bcb8CA08a2BFE917E817AFc05dbBB3`](https://bscscan.com/address/0x25d17eA0e3Bcb8CA08a2BFE917E817AFc05dbBB3) | Policy validation engine |
+| SpendingLimitPolicyV2 | [`0x28efC8D513D44252EC26f710764ADe22b2569115`](https://bscscan.com/address/0x28efC8D513D44252EC26f710764ADe22b2569115) | Per-action/daily caps |
+| CooldownPolicy | [`0x0E0B2006DE4d68543C4069249a075C215510efDB`](https://bscscan.com/address/0x0E0B2006DE4d68543C4069249a075C215510efDB) | Time intervals |
+| ReceiverGuardPolicyV2 | [`0x7A9618ec6c2e9D93712326a7797A829895c0AfF6`](https://bscscan.com/address/0x7A9618ec6c2e9D93712326a7797A829895c0AfF6) | Address whitelist |
+| DeFiGuardPolicyV2 | [`0xD1b6a97400Bc62ed6000714E9810F36Fc1a251f1`](https://bscscan.com/address/0xD1b6a97400Bc62ed6000714E9810F36Fc1a251f1) | Function filtering |
+| DexWhitelistPolicy | [`0x0D423290A050187AA15B7567aa9DB32535cEF8fb`](https://bscscan.com/address/0x0D423290A050187AA15B7567aa9DB32535cEF8fb) | DEX router whitelist |
+| TokenWhitelistPolicy | [`0x4300e2111DB1DB41d74C98fAde2DB432DceF4dBA`](https://bscscan.com/address/0x4300e2111DB1DB41d74C98fAde2DB432DceF4dBA) | Token whitelist |
+
+### Test Coverage
+
+- **278 / 278 Foundry test cases passing** (100% pass rate)
+- Test suite covers: policy validation, fail-close behavior, edge cases, access control, reentrancy
+- All contracts verified on BscScan with source code published
+
+### Audit Status
+
+- Internal security review completed
+- All contracts are open source: [github.com/shll-protocol/shll](https://github.com/shll-protocol/shll)
+- Community audit welcome — issues can be reported via GitHub
+
+## Standards Compliance
+
+| Standard | Usage |
+|---|---|
+| **BAP-578** | Non-Fungible Agent Token Standard — agent identity and lifecycle |
+| **ERC-6551** | Token Bound Accounts — isolated per-agent fund vaults |
+| **ERC-4907** | Rentable NFT — time-limited agent leasing |
+| **ERC-8004** | On-chain Agent Identity Registry — discoverability |
+
+## Links
+
+- **Production**: [shll.run](https://shll.run)
+- **Source Code**: [github.com/shll-protocol/shll](https://github.com/shll-protocol/shll)
+- **npm Package**: [shll-skills](https://www.npmjs.com/package/shll-skills) (CLI + MCP Server)
+- **Twitter**: [@shllrun](https://twitter.com/shllrun)

--- a/contracts/extensions/IPolicy.sol
+++ b/contracts/extensions/IPolicy.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IPolicy — Composable Policy Plugin Interface
+/// @author SHLL Protocol (https://github.com/shll-protocol/shll)
+/// @notice Standard interface for NFA agent action validation policies.
+///         Each policy is a standalone contract that validates a single aspect
+///         of an action (e.g. token whitelist, spending limit, cooldown).
+///
+///         BAP-578 Extension: Policy Validation Framework
+///         Extends §4.7 Security Mechanisms with granular, per-transaction enforcement.
+interface IPolicy {
+    /// @notice Validate whether an action is allowed under this policy
+    /// @param tokenId   The NFA token ID
+    /// @param caller    The address that initiated the execute call
+    /// @param target    The target contract of the action
+    /// @param selector  The function selector (first 4 bytes of calldata)
+    /// @param callData  The full calldata of the action
+    /// @param value     The native value (BNB) sent with the action
+    /// @return ok       True if the action passes this policy
+    /// @return reason   Human-readable rejection reason (empty if ok)
+    function check(
+        uint256 tokenId,
+        address caller,
+        address target,
+        bytes4 selector,
+        bytes calldata callData,
+        uint256 value
+    ) external view returns (bool ok, string memory reason);
+
+    /// @notice Returns the policy type identifier
+    /// @dev Standard types defined in PolicyTypes.sol
+    /// @return The keccak256 hash of the policy type string
+    function policyType() external pure returns (bytes32);
+
+    /// @notice Whether this policy can be modified by the agent renter
+    /// @dev Core security policies (e.g. ReceiverGuard) return false —
+    ///      only the owner can configure them. Policies like TokenWhitelist
+    ///      return true — renters can add tokens within the owner's ceiling.
+    function renterConfigurable() external pure returns (bool);
+}

--- a/contracts/extensions/IPolicyGuard.sol
+++ b/contracts/extensions/IPolicyGuard.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IPolicyGuard — On-Chain Firewall Interface
+/// @author SHLL Protocol (https://github.com/shll-protocol/shll)
+/// @notice Coordinates multiple IPolicy validators for NFA agent actions.
+///         The PolicyGuard acts as a composable policy engine that enforces
+///         all active policies before any agent action is executed.
+///
+///         BAP-578 Extension: Policy Validation Framework
+///         Extends §4.7 Security Mechanisms.
+///
+///         Design principle: FAIL-CLOSE
+///         - If ANY policy returns false, the entire action is blocked.
+///         - If a policy contract reverts, the action is blocked.
+///         - Only explicit ok=true from ALL policies permits execution.
+interface IPolicyGuard {
+    /// @notice Validate an action against all active policies
+    /// @param nfa          The AgentNFA contract address
+    /// @param tokenId      The NFA token ID
+    /// @param agentAccount The agent's vault/account address
+    /// @param caller       The address that initiated the execute call
+    /// @param target       The target contract of the action
+    /// @param value        The native value (BNB) sent with the action
+    /// @param data         The full calldata of the action
+    /// @return ok          Whether all policies pass
+    /// @return reason      Human-readable rejection reason (empty if ok)
+    function validate(
+        address nfa,
+        uint256 tokenId,
+        address agentAccount,
+        address caller,
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external view returns (bool ok, string memory reason);
+
+    /// @notice Post-execution state update
+    /// @dev Called after successful action execution for stateful policies
+    ///      (e.g. SpendingLimit tracks daily cumulative spending)
+    /// @param tokenId The NFA token ID
+    /// @param target  The target contract of the executed action
+    /// @param value   The native value sent
+    /// @param data    The calldata that was executed
+    function commit(
+        uint256 tokenId,
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external;
+
+    /// @notice Register a policy in the global approved set
+    /// @param policy The IPolicy contract address
+    function registerPolicy(address policy) external;
+
+    /// @notice Remove a policy from the global approved set
+    /// @param policy The IPolicy contract address
+    function removePolicy(address policy) external;
+
+    /// @notice Get all registered policies
+    /// @return Array of IPolicy contract addresses
+    function getRegisteredPolicies() external view returns (address[] memory);
+
+    /// @notice Bind a set of policies to a specific agent
+    /// @param tokenId  The NFA token ID
+    /// @param policies Array of IPolicy addresses to bind
+    function bindPolicies(
+        uint256 tokenId,
+        address[] calldata policies
+    ) external;
+
+    /// @notice Get all policies bound to a specific agent
+    /// @param tokenId The NFA token ID
+    /// @return Array of IPolicy contract addresses
+    function getBoundPolicies(
+        uint256 tokenId
+    ) external view returns (address[] memory);
+
+    // --- Events ---
+
+    event ActionValidated(
+        uint256 indexed tokenId,
+        address indexed target,
+        bool allowed,
+        string reason
+    );
+
+    event ActionCommitted(uint256 indexed tokenId, address indexed target);
+
+    event PolicyRegistered(address indexed policy, bytes32 policyType);
+
+    event PolicyRemoved(address indexed policy);
+
+    event PoliciesBound(uint256 indexed tokenId, address[] policies);
+}

--- a/contracts/extensions/IPolicyGuard.sol
+++ b/contracts/extensions/IPolicyGuard.sol
@@ -42,12 +42,7 @@ interface IPolicyGuard {
     /// @param target  The target contract of the executed action
     /// @param value   The native value sent
     /// @param data    The calldata that was executed
-    function commit(
-        uint256 tokenId,
-        address target,
-        uint256 value,
-        bytes calldata data
-    ) external;
+    function commit(uint256 tokenId, address target, uint256 value, bytes calldata data) external;
 
     /// @notice Register a policy in the global approved set
     /// @param policy The IPolicy contract address
@@ -64,17 +59,12 @@ interface IPolicyGuard {
     /// @notice Bind a set of policies to a specific agent
     /// @param tokenId  The NFA token ID
     /// @param policies Array of IPolicy addresses to bind
-    function bindPolicies(
-        uint256 tokenId,
-        address[] calldata policies
-    ) external;
+    function bindPolicies(uint256 tokenId, address[] calldata policies) external;
 
     /// @notice Get all policies bound to a specific agent
     /// @param tokenId The NFA token ID
     /// @return Array of IPolicy contract addresses
-    function getBoundPolicies(
-        uint256 tokenId
-    ) external view returns (address[] memory);
+    function getBoundPolicies(uint256 tokenId) external view returns (address[] memory);
 
     // --- Events ---
 

--- a/contracts/extensions/PolicyGuardExample.sol
+++ b/contracts/extensions/PolicyGuardExample.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "./IPolicy.sol";
+import "./IPolicyGuard.sol";
+
+/// @title PolicyGuardExample — Minimal PolicyGuard Reference Implementation
+/// @author SHLL Protocol (https://github.com/shll-protocol/shll)
+/// @notice A simplified PolicyGuard implementation demonstrating the core pattern:
+///         register policies → bind to agents → validate before execution → commit after.
+///
+///         This is a REFERENCE IMPLEMENTATION for learning and testing.
+///         For production use, see SHLL's PolicyGuardV4 at:
+///         https://bscscan.com/address/0x25d17eA0e3Bcb8CA08a2BFE917E817AFc05dbBB3
+///
+/// @dev Key design principles:
+///      1. FAIL-CLOSE: any policy failure blocks the entire action
+///      2. COMPOSABLE: agents can have different policy sets
+///      3. ON-CHAIN: enforcement lives in smart contracts, not off-chain code
+contract PolicyGuardExample is IPolicyGuard {
+    // --- State ---
+
+    /// @notice Contract owner
+    address public owner;
+
+    /// @notice Global registry of approved policies
+    address[] private _registeredPolicies;
+    mapping(address => bool) public isRegistered;
+
+    /// @notice Per-agent bound policy sets
+    mapping(uint256 => address[]) private _boundPolicies;
+
+    // --- Modifiers ---
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "PolicyGuard: not owner");
+        _;
+    }
+
+    // --- Constructor ---
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //                    ADMIN: Registry
+    // ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPolicyGuard
+    function registerPolicy(address policy) external onlyOwner {
+        require(policy != address(0), "PolicyGuard: zero address");
+        require(!isRegistered[policy], "PolicyGuard: already registered");
+
+        isRegistered[policy] = true;
+        _registeredPolicies.push(policy);
+
+        emit PolicyRegistered(policy, IPolicy(policy).policyType());
+    }
+
+    /// @inheritdoc IPolicyGuard
+    function removePolicy(address policy) external onlyOwner {
+        require(isRegistered[policy], "PolicyGuard: not registered");
+
+        isRegistered[policy] = false;
+        _removeFromArray(_registeredPolicies, policy);
+
+        emit PolicyRemoved(policy);
+    }
+
+    /// @inheritdoc IPolicyGuard
+    function getRegisteredPolicies() external view returns (address[] memory) {
+        return _registeredPolicies;
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //                  ADMIN: Agent Binding
+    // ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPolicyGuard
+    function bindPolicies(
+        uint256 tokenId,
+        address[] calldata policies
+    ) external onlyOwner {
+        // Validate all policies are registered
+        for (uint256 i = 0; i < policies.length; i++) {
+            require(
+                isRegistered[policies[i]],
+                "PolicyGuard: policy not registered"
+            );
+        }
+
+        // Replace existing bound policies
+        delete _boundPolicies[tokenId];
+        for (uint256 i = 0; i < policies.length; i++) {
+            _boundPolicies[tokenId].push(policies[i]);
+        }
+
+        emit PoliciesBound(tokenId, policies);
+    }
+
+    /// @inheritdoc IPolicyGuard
+    function getBoundPolicies(
+        uint256 tokenId
+    ) external view returns (address[] memory) {
+        return _boundPolicies[tokenId];
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //                  CORE: Validation
+    // ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPolicyGuard
+    /// @dev Iterates through ALL bound policies. FAIL-CLOSE: any failure blocks the action.
+    ///      Note: validate() is `view` — it cannot emit events. The caller (the agent's
+    ///      execute function) should emit ActionValidated after receiving the result.
+    function validate(
+        address /* nfa */,
+        uint256 tokenId,
+        address /* agentAccount */,
+        address caller,
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external view override returns (bool ok, string memory reason) {
+        address[] storage policies = _boundPolicies[tokenId];
+
+        // No policies bound = no agent configured = block
+        if (policies.length == 0) {
+            return (false, "PolicyGuard: no policies bound");
+        }
+
+        // Extract function selector from calldata
+        bytes4 selector = bytes4(0);
+        if (data.length >= 4) {
+            selector = bytes4(data[:4]);
+        }
+
+        // Check every bound policy (fail-close)
+        for (uint256 i = 0; i < policies.length; i++) {
+            (bool pOk, string memory pReason) = IPolicy(policies[i]).check(
+                tokenId,
+                caller,
+                target,
+                selector,
+                data,
+                value
+            );
+            if (!pOk) {
+                return (false, pReason);
+            }
+        }
+
+        return (true, "");
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //                  CORE: Commit
+    // ═══════════════════════════════════════════════════════
+
+    /// @inheritdoc IPolicyGuard
+    /// @dev Called after successful execution for stateful policies.
+    ///      In production (SHLL), this updates SpendingLimit daily counters.
+    function commit(
+        uint256 tokenId,
+        address target,
+        uint256 /* value */,
+        bytes calldata /* data */
+    ) external {
+        // In a full implementation, iterate bound policies and call
+        // a commit() hook on stateful ones (e.g. SpendingLimit tracking).
+        // This example emits an event as a placeholder.
+        emit ActionCommitted(tokenId, target);
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //                    INTERNAL
+    // ═══════════════════════════════════════════════════════
+
+    function _removeFromArray(address[] storage arr, address item) internal {
+        for (uint256 i = 0; i < arr.length; i++) {
+            if (arr[i] == item) {
+                arr[i] = arr[arr.length - 1];
+                arr.pop();
+                return;
+            }
+        }
+    }
+}

--- a/contracts/extensions/PolicyGuardExample.sol
+++ b/contracts/extensions/PolicyGuardExample.sol
@@ -78,16 +78,10 @@ contract PolicyGuardExample is IPolicyGuard {
     // ═══════════════════════════════════════════════════════
 
     /// @inheritdoc IPolicyGuard
-    function bindPolicies(
-        uint256 tokenId,
-        address[] calldata policies
-    ) external onlyOwner {
+    function bindPolicies(uint256 tokenId, address[] calldata policies) external onlyOwner {
         // Validate all policies are registered
         for (uint256 i = 0; i < policies.length; i++) {
-            require(
-                isRegistered[policies[i]],
-                "PolicyGuard: policy not registered"
-            );
+            require(isRegistered[policies[i]], "PolicyGuard: policy not registered");
         }
 
         // Replace existing bound policies
@@ -100,9 +94,7 @@ contract PolicyGuardExample is IPolicyGuard {
     }
 
     /// @inheritdoc IPolicyGuard
-    function getBoundPolicies(
-        uint256 tokenId
-    ) external view returns (address[] memory) {
+    function getBoundPolicies(uint256 tokenId) external view returns (address[] memory) {
         return _boundPolicies[tokenId];
     }
 

--- a/contracts/extensions/PolicyTypes.sol
+++ b/contracts/extensions/PolicyTypes.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title PolicyTypes — Standard Policy Type Identifiers
+/// @author SHLL Protocol (https://github.com/shll-protocol/shll)
+/// @notice Defines the standard policy type identifiers for BAP-578 agents.
+///         Each policy type represents a specific security constraint.
+///
+///         Four core policies provide complete coverage:
+///         - SpendingLimit: value caps (includes token whitelist in production V2)
+///         - Cooldown: time-based rate limiting
+///         - DeFiGuard: contract + function filtering (subsumes DEX whitelisting)
+///         - ReceiverGuard: output address restriction
+///
+///         Implementers MAY define custom policy types by following the same
+///         pattern: keccak256("lowercase_type_name").
+library PolicyTypes {
+    /// @notice Per-action and daily value caps
+    /// @dev Prevents overspending from hallucination or compromised operators.
+    ///      Production V2 also integrates token whitelist + approve control.
+    bytes32 internal constant SPENDING_LIMIT = keccak256("spending_limit");
+
+    /// @notice Minimum time interval between actions
+    /// @dev Prevents rapid-fire trading loops and gas drainage attacks
+    bytes32 internal constant COOLDOWN = keccak256("cooldown");
+
+    /// @notice DeFi contract + function selector filtering
+    /// @dev Controls which contracts and functions the agent can call.
+    ///      Subsumes DEX router whitelisting — no separate DEX policy needed.
+    bytes32 internal constant DEFI_GUARD = keccak256("defi_guard");
+
+    /// @notice Restrict fund recipient addresses
+    /// @dev Prevents prompt injection attacks that redirect funds to attacker wallets.
+    ///      Fail-close: no whitelist = no outbound transfers allowed.
+    bytes32 internal constant RECEIVER_GUARD = keccak256("receiver_guard");
+}

--- a/contracts/extensions/SpendingLimitExample.sol
+++ b/contracts/extensions/SpendingLimitExample.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "./IPolicy.sol";
+import "./PolicyTypes.sol";
+
+/// @title SpendingLimitExample — Example Policy Implementation
+/// @author SHLL Protocol (https://github.com/shll-protocol/shll)
+/// @notice Demonstrates how to implement the IPolicy interface.
+///         Enforces a per-action spending cap on native value (BNB).
+///
+///         This is a SIMPLIFIED example for learning purposes.
+///         Production version: SpendingLimitPolicyV2
+///         https://bscscan.com/address/0x28efC8D513D44252EC26f710764ADe22b2569115
+contract SpendingLimitExample is IPolicy {
+    /// @notice Per-agent spending limit in wei
+    mapping(uint256 => uint256) public limits;
+
+    /// @notice Contract owner
+    address public owner;
+
+    // --- Events ---
+    event LimitSet(uint256 indexed tokenId, uint256 limit);
+
+    // --- Constructor ---
+    constructor() {
+        owner = msg.sender;
+    }
+
+    // --- Admin ---
+
+    /// @notice Set the per-action spending limit for an agent
+    /// @param tokenId The NFA token ID
+    /// @param limit   Maximum native value per action (in wei)
+    function setLimit(uint256 tokenId, uint256 limit) external {
+        require(msg.sender == owner, "SpendingLimit: not owner");
+        limits[tokenId] = limit;
+        emit LimitSet(tokenId, limit);
+    }
+
+    // --- IPolicy Implementation ---
+
+    /// @inheritdoc IPolicy
+    function check(
+        uint256 tokenId,
+        address /* caller */,
+        address /* target */,
+        bytes4 /* selector */,
+        bytes calldata /* callData */,
+        uint256 value
+    ) external view override returns (bool ok, string memory reason) {
+        uint256 limit = limits[tokenId];
+
+        // Fail-close: if no limit is configured, block all valued actions
+        if (limit == 0 && value > 0) {
+            return (false, "SpendingLimit: no limit configured");
+        }
+
+        // Check against limit
+        if (value > limit) {
+            return (false, "SpendingLimit: exceeds per-action limit");
+        }
+
+        return (true, "");
+    }
+
+    /// @inheritdoc IPolicy
+    function policyType() external pure override returns (bytes32) {
+        return PolicyTypes.SPENDING_LIMIT;
+    }
+
+    /// @inheritdoc IPolicy
+    function renterConfigurable() external pure override returns (bool) {
+        // Spending limits are owner-controlled, not renter-configurable
+        return false;
+    }
+}

--- a/docs/POLICY-GUARD-INTEGRATION.md
+++ b/docs/POLICY-GUARD-INTEGRATION.md
@@ -1,0 +1,167 @@
+# PolicyGuard Integration Guide
+
+> How to integrate the Policy Validation Framework into BAP-578 agents
+
+## Overview
+
+The PolicyGuard framework adds an on-chain security layer to BAP-578 NFA agents. It sits between the agent's action proposal and the blockchain, validating every transaction against a composable set of policies.
+
+> **Zero-dependency design**: These interfaces and examples have no dependency on SHLL's AgentNFA, ERC-6551, or ERC-4907. They work with any BAP-578 implementation — just import `IPolicy.sol` and call `validate()`. The `tokenId` parameter is a generic `uint256` that accepts any agent/token ID.
+
+```
+Agent proposes action → PolicyGuard.validate() → Policy 1 ✅ → Policy 2 ✅ → ... → Policy N ✅ → Execute
+                                                  ↓ (any fail)
+                                                  ❌ REVERT — action blocked
+```
+
+## Quick Start
+
+### 1. Deploy PolicyGuard
+
+```javascript
+// deploy-policyguard.js
+const { ethers, upgrades } = require("hardhat");
+
+async function main() {
+  // Deploy SpendingLimit policy
+  const SpendingLimit = await ethers.getContractFactory("SpendingLimitExample");
+  const spendingLimit = await SpendingLimit.deploy();
+  await spendingLimit.deployed();
+  console.log("SpendingLimit:", spendingLimit.address);
+
+  // Deploy PolicyGuard
+  const PolicyGuard = await ethers.getContractFactory("PolicyGuardExample");
+  const guard = await PolicyGuard.deploy();
+  await guard.deployed();
+  console.log("PolicyGuard:", guard.address);
+
+  // Register policy
+  await guard.registerPolicy(spendingLimit.address);
+
+  // Bind policy to agent tokenId=1
+  await guard.bindPolicies(1, [spendingLimit.address]);
+
+  // Configure spending limit: 0.1 BNB per action
+  await spendingLimit.setLimit(1, ethers.utils.parseEther("0.1"));
+}
+
+main();
+```
+
+### 2. Integrate with BAP578 Contract
+
+To add PolicyGuard validation to the existing `BAP578.sol`, add a `policyGuard` state variable and validate actions before execution:
+
+```solidity
+// Add to BAP578.sol state variables:
+IPolicyGuard public policyGuard;
+
+// Add setter:
+function setPolicyGuard(address _guard) external onlyOwner {
+    policyGuard = IPolicyGuard(_guard);
+}
+
+// Example: Add policy validation to withdrawFromAgent
+function withdrawFromAgent(
+    uint256 tokenId,
+    uint256 amount
+) external onlyTokenOwner(tokenId) nonReentrant {
+    require(agentStates[tokenId].balance >= amount, "Insufficient balance");
+
+    // --- PolicyGuard validation ---
+    if (address(policyGuard) != address(0)) {
+        (bool allowed, string memory reason) = policyGuard.validate(
+            address(this),           // nfa
+            tokenId,                 // tokenId
+            address(this),           // agentAccount
+            msg.sender,              // caller
+            msg.sender,              // target (withdrawal destination)
+            amount,                  // value
+            ""                       // no calldata for simple transfer
+        );
+        require(allowed, reason);
+    }
+
+    // Existing logic...
+    agentStates[tokenId].balance -= amount;
+    emit AgentWithdraw(tokenId, amount);
+    (bool success, ) = payable(msg.sender).call{ value: amount }("");
+    require(success, "Withdrawal failed");
+}
+```
+
+### 3. Implement Custom Policies
+
+To create a custom policy, implement the `IPolicy` interface:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "./extensions/IPolicy.sol";
+
+contract MyCustomPolicy is IPolicy {
+    function check(
+        uint256 tokenId,
+        address caller,
+        address target,
+        bytes4 selector,
+        bytes calldata callData,
+        uint256 value
+    ) external view override returns (bool ok, string memory reason) {
+        // Your validation logic here
+        // Return (true, "") to allow, (false, "reason") to block
+    }
+
+    function policyType() external pure override returns (bytes32) {
+        return keccak256("my_custom_policy");
+    }
+
+    function renterConfigurable() external pure override returns (bool) {
+        return false; // only owner can manage
+    }
+}
+```
+
+## Architecture Patterns
+
+### Pattern 1: Pre-execution Validation (View-only)
+
+The `validate()` function is `view` — it reads state but does not modify it. This means:
+- Validation can be called without gas cost (off-chain `eth_call`)
+- Multiple policies can be checked atomically
+- No state corruption risk during validation
+
+### Pattern 2: Post-execution Commit (State-changing)
+
+The `commit()` function is called **after** successful execution to update stateful policies. Example: SpendingLimit tracks cumulative daily spending.
+
+```
+validate() → passes → execute action → commit() → update daily counter
+```
+
+### Pattern 3: Template/Instance Hierarchy
+
+In SHLL's production system, policies support a template/instance model:
+- **Template policies** are set by the agent creator (ceiling)
+- **Instance policies** are set by the renter (within ceiling)
+- A renter cannot remove non-`renterConfigurable` policies
+
+## Standard Policy Types (4 Core Policies)
+
+| Type ID | Purpose | Example Configuration |
+|---|---|---|
+| `spending_limit` | Per-action value caps + token whitelist + approve control (V2) | Max 0.1 BNB per swap; only USDT, WBNB allowed |
+| `cooldown` | Time intervals | 300 sec between actions |
+| `defi_guard` | Contract + function selector filtering (subsumes DEX whitelisting) | Only PancakeSwap V2/V3 `swapExactTokens` allowed |
+| `receiver_guard` | Output address whitelist | Only agent vault address allowed |
+
+> **Note**: Earlier designs had separate `dex_whitelist` and `token_whitelist` policies. These are now subsumed by `defi_guard` (target + selector control) and `spending_limit` (token + approve control) respectively.
+
+## Production Reference
+
+For a complete, battle-tested implementation, see SHLL Protocol:
+
+- **PolicyGuardV4**: [BscScan](https://bscscan.com/address/0x25d17eA0e3Bcb8CA08a2BFE917E817AFc05dbBB3)
+- **Source Code**: [github.com/shll-protocol/shll](https://github.com/shll-protocol/shll)
+- **npm Package**: `npm install -g shll-skills`

--- a/test/PolicyGuard.test.js
+++ b/test/PolicyGuard.test.js
@@ -1,0 +1,258 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('PolicyGuard Extension', function () {
+    let owner, operator, attacker;
+    let policyGuard, spendingLimit;
+
+    beforeEach(async function () {
+        [owner, operator, attacker] = await ethers.getSigners();
+
+        // Deploy SpendingLimitExample
+        const SpendingLimit = await ethers.getContractFactory('SpendingLimitExample');
+        spendingLimit = await SpendingLimit.deploy();
+        await spendingLimit.deployed();
+
+        // Deploy PolicyGuardExample
+        const PolicyGuard = await ethers.getContractFactory('PolicyGuardExample');
+        policyGuard = await PolicyGuard.deploy();
+        await policyGuard.deployed();
+    });
+
+    // ============================================
+    //              IPolicy Interface Tests
+    // ============================================
+
+    describe('IPolicy: SpendingLimitExample', function () {
+        it('should return correct policyType', async function () {
+            const policyType = await spendingLimit.policyType();
+            const expected = ethers.utils.keccak256(
+                ethers.utils.toUtf8Bytes('spending_limit'),
+            );
+            expect(policyType).to.equal(expected);
+        });
+
+        it('should return renterConfigurable as false', async function () {
+            expect(await spendingLimit.renterConfigurable()).to.equal(false);
+        });
+
+        it('should allow actions within spending limit', async function () {
+            const tokenId = 1;
+            const limit = ethers.utils.parseEther('0.1'); // 0.1 BNB
+            await spendingLimit.setLimit(tokenId, limit);
+
+            const value = ethers.utils.parseEther('0.05'); // 0.05 BNB — under limit
+            const [ok, reason] = await spendingLimit.check(
+                tokenId,
+                operator.address,
+                ethers.constants.AddressZero,
+                '0x00000000',
+                '0x',
+                value,
+            );
+
+            expect(ok).to.equal(true);
+            expect(reason).to.equal('');
+        });
+
+        it('should block actions exceeding spending limit', async function () {
+            const tokenId = 1;
+            const limit = ethers.utils.parseEther('0.1'); // 0.1 BNB
+            await spendingLimit.setLimit(tokenId, limit);
+
+            const value = ethers.utils.parseEther('1.0'); // 1.0 BNB — exceeds limit
+            const [ok, reason] = await spendingLimit.check(
+                tokenId,
+                operator.address,
+                ethers.constants.AddressZero,
+                '0x00000000',
+                '0x',
+                value,
+            );
+
+            expect(ok).to.equal(false);
+            expect(reason).to.equal('SpendingLimit: exceeds per-action limit');
+        });
+
+        it('should block valued actions when no limit is configured (fail-close)', async function () {
+            const tokenId = 99; // No limit configured
+            const value = ethers.utils.parseEther('0.01'); // Any value > 0
+
+            const [ok, reason] = await spendingLimit.check(
+                tokenId,
+                operator.address,
+                ethers.constants.AddressZero,
+                '0x00000000',
+                '0x',
+                value,
+            );
+
+            expect(ok).to.equal(false);
+            expect(reason).to.equal('SpendingLimit: no limit configured');
+        });
+
+        it('should allow zero-value actions even without a limit', async function () {
+            const tokenId = 99; // No limit configured
+            const value = 0;
+
+            const [ok, reason] = await spendingLimit.check(
+                tokenId,
+                operator.address,
+                ethers.constants.AddressZero,
+                '0x00000000',
+                '0x',
+                value,
+            );
+
+            expect(ok).to.equal(true);
+        });
+
+        it('should only allow owner to set limits', async function () {
+            await expect(
+                spendingLimit.connect(attacker).setLimit(1, ethers.utils.parseEther('1.0')),
+            ).to.be.revertedWith('SpendingLimit: not owner');
+        });
+    });
+
+    // ============================================
+    //            IPolicyGuard Interface Tests
+    // ============================================
+
+    describe('IPolicyGuard: PolicyGuardExample', function () {
+        describe('Policy Registry', function () {
+            it('should register a policy', async function () {
+                await policyGuard.registerPolicy(spendingLimit.address);
+                expect(await policyGuard.isRegistered(spendingLimit.address)).to.equal(true);
+
+                const policies = await policyGuard.getRegisteredPolicies();
+                expect(policies.length).to.equal(1);
+                expect(policies[0]).to.equal(spendingLimit.address);
+            });
+
+            it('should prevent duplicate registration', async function () {
+                await policyGuard.registerPolicy(spendingLimit.address);
+                await expect(
+                    policyGuard.registerPolicy(spendingLimit.address),
+                ).to.be.revertedWith('PolicyGuard: already registered');
+            });
+
+            it('should prevent zero-address registration', async function () {
+                await expect(
+                    policyGuard.registerPolicy(ethers.constants.AddressZero),
+                ).to.be.revertedWith('PolicyGuard: zero address');
+            });
+
+            it('should remove a policy', async function () {
+                await policyGuard.registerPolicy(spendingLimit.address);
+                await policyGuard.removePolicy(spendingLimit.address);
+
+                expect(await policyGuard.isRegistered(spendingLimit.address)).to.equal(false);
+                const policies = await policyGuard.getRegisteredPolicies();
+                expect(policies.length).to.equal(0);
+            });
+
+            it('should only allow owner to register/remove policies', async function () {
+                await expect(
+                    policyGuard.connect(attacker).registerPolicy(spendingLimit.address),
+                ).to.be.revertedWith('PolicyGuard: not owner');
+            });
+        });
+
+        describe('Policy Binding', function () {
+            beforeEach(async function () {
+                await policyGuard.registerPolicy(spendingLimit.address);
+            });
+
+            it('should bind policies to an agent', async function () {
+                await policyGuard.bindPolicies(1, [spendingLimit.address]);
+
+                const bound = await policyGuard.getBoundPolicies(1);
+                expect(bound.length).to.equal(1);
+                expect(bound[0]).to.equal(spendingLimit.address);
+            });
+
+            it('should reject binding unregistered policies', async function () {
+                await expect(
+                    policyGuard.bindPolicies(1, [attacker.address]),
+                ).to.be.revertedWith('PolicyGuard: policy not registered');
+            });
+
+            it('should only allow owner to bind policies', async function () {
+                await expect(
+                    policyGuard.connect(attacker).bindPolicies(1, [spendingLimit.address]),
+                ).to.be.revertedWith('PolicyGuard: not owner');
+            });
+        });
+
+        describe('Validation — Fail-Close Logic', function () {
+            const tokenId = 1;
+
+            it('should block actions when no policies are bound (fail-close)', async function () {
+                // tokenId=99 has no policies bound
+                const [ok, reason] = await policyGuard.validate(
+                    ethers.constants.AddressZero,
+                    99,
+                    ethers.constants.AddressZero,
+                    operator.address,
+                    ethers.constants.AddressZero,
+                    0,
+                    '0x',
+                );
+
+                expect(ok).to.equal(false);
+                expect(reason).to.equal('PolicyGuard: no policies bound');
+            });
+
+            it('should allow actions that pass all policies', async function () {
+                // Setup: register, bind, configure
+                await policyGuard.registerPolicy(spendingLimit.address);
+                await policyGuard.bindPolicies(tokenId, [spendingLimit.address]);
+                await spendingLimit.setLimit(tokenId, ethers.utils.parseEther('1.0'));
+
+                const [ok, reason] = await policyGuard.validate(
+                    ethers.constants.AddressZero,
+                    tokenId,
+                    ethers.constants.AddressZero,
+                    operator.address,
+                    ethers.constants.AddressZero,
+                    ethers.utils.parseEther('0.5'), // Under limit
+                    '0x',
+                );
+
+                expect(ok).to.equal(true);
+                expect(reason).to.equal('');
+            });
+
+            it('should block actions that fail any policy', async function () {
+                // Setup: register, bind, configure
+                await policyGuard.registerPolicy(spendingLimit.address);
+                await policyGuard.bindPolicies(tokenId, [spendingLimit.address]);
+                await spendingLimit.setLimit(tokenId, ethers.utils.parseEther('0.1'));
+
+                const [ok, reason] = await policyGuard.validate(
+                    ethers.constants.AddressZero,
+                    tokenId,
+                    ethers.constants.AddressZero,
+                    operator.address,
+                    ethers.constants.AddressZero,
+                    ethers.utils.parseEther('5.0'), // Exceeds limit
+                    '0x',
+                );
+
+                expect(ok).to.equal(false);
+                expect(reason).to.equal('SpendingLimit: exceeds per-action limit');
+            });
+        });
+
+        describe('Commit', function () {
+            it('should emit ActionCommitted event', async function () {
+                const tokenId = 1;
+                const target = operator.address;
+
+                await expect(policyGuard.commit(tokenId, target, 0, '0x'))
+                    .to.emit(policyGuard, 'ActionCommitted')
+                    .withArgs(tokenId, target);
+            });
+        });
+    });
+});


### PR DESCRIPTION
> Contributed by [SHLL Protocol](https://github.com/shll-protocol/shll) — the first production implementation of BAP-578 with on-chain policy enforcement on BSC Mainnet.

### Summary

Add a **composable, on-chain Policy Validation Framework** extending BAP-578 Section 4.7 Security Mechanisms. This introduces standard interfaces (IPolicy, IPolicyGuard) and a reference implementation for enforcing per-transaction constraints on NFA agent actions.

**This PR does NOT modify the existing BAP578.sol contract.** It adds new extension contracts, documentation, and tests alongside the existing codebase.

### What's Included

| Category | Files | Description |
|---|---|---|
| **Interfaces** | contracts/extensions/IPolicy.sol | Standard policy plugin interface |
| | contracts/extensions/IPolicyGuard.sol | Policy engine coordinator interface |
| | contracts/extensions/PolicyTypes.sol | 4 core policy type identifiers |
| **Examples** | contracts/extensions/PolicyGuardExample.sol | Minimal PolicyGuard implementation |
| | contracts/extensions/SpendingLimitExample.sol | Example spending limit policy |
| **Security** | SECURITY.md | Threat model, 4-core policy matrix, security checklist |
| **Docs** | docs/POLICY-GUARD-INTEGRATION.md | Integration guide with code examples |
| **Tests** | test/PolicyGuard.test.js | Hardhat test suite (19 test cases) |

### Design Principles

1. **Fail-close**: Any policy failure blocks the entire action
2. **Composable**: Agents can have different policy sets
3. **On-chain only**: Smart contract enforcement, not off-chain checks
4. **Non-breaking**: Extension contracts only, no changes to BAP578.sol
5. **Zero-dependency**: No dependency on SHLL AgentNFA, ERC-6551, or ERC-4907. Any BAP-578 implementation can adopt directly

### Security Checklist

- Reentrancy protection (CEI pattern)
- Access control (owner-only admin functions)
- Fail-close by default
- View-only validation
- No delegatecall in policies

### Production Reference

- 12 verified contracts on BSC Mainnet
- 278/278 Foundry test cases passing (100%)
- BscScan: https://bscscan.com/address/0x25d17eA0e3Bcb8CA08a2BFE917E817AFc05dbBB3
- Source: https://github.com/shll-protocol/shll

### Breaking Changes

**None.** This PR adds new files only.
### Checklist

- [x] Interfaces: IPolicy + IPolicyGuard + PolicyTypes
- [x] Example implementations: PolicyGuardExample + SpendingLimitExample
- [x] Security audit: SECURITY.md with threat model and policy matrix
- [x] Integration guide: docs/POLICY-GUARD-INTEGRATION.md
- [x] Test suite: 19 Hardhat test cases passing
- [x] Zero dependency: no imports from external projects
- [x] Non-breaking: no changes to existing BAP578.sol