### PR TITLE
feat(extensions): add VaultPermissionManager actor-authorization layer

### DIFF
--- a/contracts/extensions/IVaultPermissionManager.sol
+++ b/contracts/extensions/IVaultPermissionManager.sol
@@ -42,6 +42,15 @@ interface IVaultPermissionManager {
         string action
     );
 
+    /// @notice Emitted when the contract observes that a token changed owner.
+    ///         Every grant issued under `previousOwner` is invalid from here on.
+    event OwnerEpochAdvanced(
+        uint256 indexed tokenId,
+        address indexed previousOwner,
+        address indexed newOwner,
+        uint256 newEpoch
+    );
+
     // ---- Writes -----------------------------------------------------------
 
     /// @notice Create a new permission namespace for an agent.
@@ -55,8 +64,10 @@ interface IVaultPermissionManager {
 
     /// @notice Grant a permission tier to a grantee on a vault.
     /// @param expiry Unix timestamp; 0 means no expiry. Past timestamps revert.
-    /// @dev Callable by the NFT owner or an address that already holds ADMIN
-    ///      on the same (tokenId, vaultId).
+    /// @dev Callable by the NFT owner, or by an address holding ADMIN on the
+    ///      same (tokenId, vaultId). A grantor cannot grant to itself, and only
+    ///      the NFT owner may grant or renew the ADMIN tier: an ADMIN can grant
+    ///      READ / WRITE but cannot create further admins or renew its own grant.
     function grantPermission(
         uint256 tokenId,
         string calldata vaultId,
@@ -85,6 +96,14 @@ interface IVaultPermissionManager {
         bytes calldata data
     ) external returns (bytes memory result);
 
+    /// @notice Commit the token's current owner into contract state, advancing
+    ///         the owner epoch if it changed.
+    /// @dev Callable by anyone. Every state-changing function above also does
+    ///      this implicitly; `syncOwner` exists so an off-chain indexer watching
+    ///      BAP-578 Transfer events can invalidate stale grants on a token that
+    ///      would otherwise round-trip owners with no other VPM activity.
+    function syncOwner(uint256 tokenId) external;
+
     // ---- Reads ------------------------------------------------------------
 
     /// @notice Whether `accessor` currently holds at least `minLevel`.
@@ -108,4 +127,9 @@ interface IVaultPermissionManager {
 
     /// @notice Whether the named vault exists on the agent.
     function vaultExists(uint256 tokenId, string calldata vaultId) external view returns (bool);
+
+    /// @notice The token's current owner epoch. A grant is valid only while its
+    ///         stamped epoch matches this value; the epoch advances on every
+    ///         observed owner change, so a transfer invalidates prior grants.
+    function ownerEpoch(uint256 tokenId) external view returns (uint256);
 }

--- a/contracts/extensions/IVaultPermissionManager.sol
+++ b/contracts/extensions/IVaultPermissionManager.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IVaultPermissionManager: actor-authorization layer for BAP-578 agents
+/// @notice Lets a BAP-578 NFT owner grant a third-party operator the right to
+///         drive their agent's `handleAction` entry point, within a time-bounded
+///         permission tier. The operator never holds the NFT and cannot transfer
+///         it, list it, or change its logic.
+///
+///         Complementary to the IPolicyGuard framework already in this repo:
+///           - IPolicyGuard answers "is this action ALLOWED?" (per-call validation,
+///             typically of the logic's outbound calls to external contracts).
+///           - IVaultPermissionManager answers "is this ACTOR authorized to drive
+///             handleAction at all?" (per-actor authorization at the outer boundary).
+///
+///         A full agent stack uses both: the operator passes through the VPM
+///         forwarder, the logic module's outbound calls are validated by
+///         IPolicyGuard. See EXTENSION-README.md for the composition pattern.
+interface IVaultPermissionManager {
+    /// @notice Permission tiers. Higher tiers strictly include lower tiers.
+    enum PermissionLevel { NONE, READ, WRITE, ADMIN }
+
+    // ---- Events -----------------------------------------------------------
+
+    event VaultCreated(uint256 indexed tokenId, bytes32 indexed vaultIdHash, string vaultId, address creator);
+
+    event PermissionGranted(
+        uint256 indexed tokenId,
+        bytes32 indexed vaultIdHash,
+        address indexed grantee,
+        PermissionLevel level,
+        uint256 expiry,
+        string description
+    );
+
+    event PermissionRevoked(uint256 indexed tokenId, bytes32 indexed vaultIdHash, address indexed grantee);
+
+    event ActionForwarded(
+        uint256 indexed tokenId,
+        bytes32 indexed vaultIdHash,
+        address indexed accessor,
+        string action
+    );
+
+    // ---- Writes -----------------------------------------------------------
+
+    /// @notice Create a new permission namespace for an agent.
+    /// @dev Callable by the NFT owner only. An agent may have multiple vaults
+    ///      (e.g. separate scopes for trading vs. social vs. memory writes).
+    function createVault(
+        uint256 tokenId,
+        string calldata vaultId,
+        string calldata description
+    ) external;
+
+    /// @notice Grant a permission tier to a grantee on a vault.
+    /// @param expiry Unix timestamp; 0 means no expiry. Past timestamps revert.
+    /// @dev Callable by the NFT owner or an address that already holds ADMIN
+    ///      on the same (tokenId, vaultId).
+    function grantPermission(
+        uint256 tokenId,
+        string calldata vaultId,
+        address grantee,
+        PermissionLevel level,
+        uint256 expiry,
+        string calldata description
+    ) external;
+
+    /// @notice Revoke an existing grant.
+    /// @dev Callable by the NFT owner or an ADMIN on the same vault.
+    function revokePermission(
+        uint256 tokenId,
+        string calldata vaultId,
+        address grantee
+    ) external;
+
+    /// @notice Forward an action to the agent's bound logic module.
+    /// @dev msg.sender must have at least WRITE on (tokenId, vaultId). Reverts
+    ///      with the logic module's revert reason if the inner call reverts.
+    /// @return result Whatever bytes the logic module returns (often empty).
+    function forwardHandleAction(
+        uint256 tokenId,
+        string calldata vaultId,
+        string calldata action,
+        bytes calldata data
+    ) external returns (bytes memory result);
+
+    // ---- Reads ------------------------------------------------------------
+
+    /// @notice Whether `accessor` currently holds at least `minLevel`.
+    /// @return ok      True iff the grant exists, is at or above `minLevel`, and
+    ///                 has not expired (or has no expiry).
+    /// @return expiry  The grant's expiry timestamp (0 = no expiry), or 0 if no grant.
+    function checkPermission(
+        uint256 tokenId,
+        string calldata vaultId,
+        address accessor,
+        PermissionLevel minLevel
+    ) external view returns (bool ok, uint256 expiry);
+
+    /// @notice Convenience helper used by forwarders before dispatching.
+    /// @dev Equivalent to checkPermission(..., WRITE).ok.
+    function canForward(
+        uint256 tokenId,
+        string calldata vaultId,
+        address accessor
+    ) external view returns (bool);
+
+    /// @notice Whether the named vault exists on the agent.
+    function vaultExists(uint256 tokenId, string calldata vaultId) external view returns (bool);
+}

--- a/contracts/extensions/IVaultPermissionManager.sol
+++ b/contracts/extensions/IVaultPermissionManager.sol
@@ -18,11 +18,21 @@ pragma solidity ^0.8.28;
 ///         IPolicyGuard. See EXTENSION-README.md for the composition pattern.
 interface IVaultPermissionManager {
     /// @notice Permission tiers. Higher tiers strictly include lower tiers.
-    enum PermissionLevel { NONE, READ, WRITE, ADMIN }
+    enum PermissionLevel {
+        NONE,
+        READ,
+        WRITE,
+        ADMIN
+    }
 
     // ---- Events -----------------------------------------------------------
 
-    event VaultCreated(uint256 indexed tokenId, bytes32 indexed vaultIdHash, string vaultId, address creator);
+    event VaultCreated(
+        uint256 indexed tokenId,
+        bytes32 indexed vaultIdHash,
+        string vaultId,
+        address creator
+    );
 
     event PermissionGranted(
         uint256 indexed tokenId,
@@ -33,7 +43,11 @@ interface IVaultPermissionManager {
         string description
     );
 
-    event PermissionRevoked(uint256 indexed tokenId, bytes32 indexed vaultIdHash, address indexed grantee);
+    event PermissionRevoked(
+        uint256 indexed tokenId,
+        bytes32 indexed vaultIdHash,
+        address indexed grantee
+    );
 
     event ActionForwarded(
         uint256 indexed tokenId,
@@ -79,11 +93,7 @@ interface IVaultPermissionManager {
 
     /// @notice Revoke an existing grant.
     /// @dev Callable by the NFT owner or an ADMIN on the same vault.
-    function revokePermission(
-        uint256 tokenId,
-        string calldata vaultId,
-        address grantee
-    ) external;
+    function revokePermission(uint256 tokenId, string calldata vaultId, address grantee) external;
 
     /// @notice Forward an action to the agent's bound logic module.
     /// @dev msg.sender must have at least WRITE on (tokenId, vaultId). Reverts

--- a/contracts/extensions/VaultPermissionManagerReference.sol
+++ b/contracts/extensions/VaultPermissionManagerReference.sol
@@ -36,6 +36,13 @@ interface ILogicModuleForwardable {
 ///         Vault IDs are user-supplied strings (kept for human readability in
 ///         events), hashed to bytes32 for storage lookups.
 ///
+///         Auto-revoke on NFT transfer is enforced through a per-token owner
+///         epoch (see `_syncEpoch` / `_currentEpoch`): every grant stamps the
+///         epoch live at creation, and a grant is invalid once the epoch moves.
+///         The epoch advances whenever the contract observes a new owner, so a
+///         grant from a previous owner cannot reactivate on an NFT round-trip
+///         that the contract observed.
+///
 ///         Production deployments should add: pause guard, per-action policy
 ///         hooks (see EXTENSION-README.md for the IPolicyGuard composition
 ///         pattern), and indexer-friendly events.
@@ -50,8 +57,8 @@ contract VaultPermissionManagerReference is
 
     struct Grant {
         PermissionLevel level;
-        uint256 expiry;       // 0 = no expiry
-        address ownerAtGrant; // ownerOf(tokenId) at the time the grant was created
+        uint256 expiry; // 0 = no expiry
+        uint256 epoch;  // owner epoch of the token when this grant was created
         bool exists;
     }
 
@@ -63,8 +70,14 @@ contract VaultPermissionManagerReference is
     // tokenId => vaultIdHash => grantee => Grant
     mapping(uint256 => mapping(bytes32 => mapping(address => Grant))) private _grants;
 
+    // tokenId => owner epoch. Advances every time the contract observes a new owner.
+    mapping(uint256 => uint256) private _ownerEpoch;
+
+    // tokenId => the owner address the contract last observed.
+    mapping(uint256 => address) private _lastSeenOwner;
+
     // Reserved storage for future upgrades.
-    uint256[50] private __gap;
+    uint256[48] private __gap;
 
     // ---- Initializer ------------------------------------------------------
 
@@ -83,16 +96,6 @@ contract VaultPermissionManagerReference is
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
-    // ---- Modifiers --------------------------------------------------------
-
-    modifier onlyTokenOwnerOrAdmin(uint256 tokenId, bytes32 vid) {
-        if (IBAP578(bap578).ownerOf(tokenId) != msg.sender) {
-            (bool ok, ) = _check(tokenId, vid, msg.sender, PermissionLevel.ADMIN);
-            require(ok, "VPM: not owner or admin");
-        }
-        _;
-    }
-
     // ---- IVaultPermissionManager writes -----------------------------------
 
     function createVault(
@@ -101,6 +104,7 @@ contract VaultPermissionManagerReference is
         string calldata /*description*/
     ) external {
         require(IBAP578(bap578).ownerOf(tokenId) == msg.sender, "VPM: only NFT owner");
+        _syncEpoch(tokenId);
         bytes32 vid = _vid(vaultId);
         require(!_vaults[tokenId][vid], "VPM: vault exists");
         _vaults[tokenId][vid] = true;
@@ -116,16 +120,29 @@ contract VaultPermissionManagerReference is
         string calldata description
     ) external {
         require(grantee != address(0), "VPM: grantee zero");
+        require(grantee != msg.sender, "VPM: cannot grant to self");
         require(level != PermissionLevel.NONE, "VPM: NONE; use revoke");
         require(expiry == 0 || expiry > block.timestamp, "VPM: expiry in past");
         bytes32 vid = _vid(vaultId);
         require(_vaults[tokenId][vid], "VPM: no such vault");
-        _authorizeGrantor(tokenId, vid);
 
+        // Only the NFT owner may mint or renew the ADMIN tier. Admins can grant
+        // READ / WRITE but cannot create further admins or renew themselves.
+        bool isOwner = IBAP578(bap578).ownerOf(tokenId) == msg.sender;
+        if (level == PermissionLevel.ADMIN) {
+            require(isOwner, "VPM: only owner grants ADMIN");
+        }
+        if (!isOwner) {
+            uint256 epoch = _currentEpoch(tokenId);
+            (bool isAdmin, ) = _check(tokenId, vid, msg.sender, PermissionLevel.ADMIN, epoch);
+            require(isAdmin, "VPM: not owner or admin");
+        }
+
+        uint256 currentEpoch = _syncEpoch(tokenId);
         _grants[tokenId][vid][grantee] = Grant({
             level: level,
             expiry: expiry,
-            ownerAtGrant: IBAP578(bap578).ownerOf(tokenId),
+            epoch: currentEpoch,
             exists: true
         });
         emit PermissionGranted(tokenId, vid, grantee, level, expiry, description);
@@ -153,7 +170,8 @@ contract VaultPermissionManagerReference is
         bytes32 vid = _vid(vaultId);
         require(_vaults[tokenId][vid], "VPM: no such vault");
 
-        (bool ok, ) = _check(tokenId, vid, msg.sender, PermissionLevel.WRITE);
+        uint256 currentEpoch = _syncEpoch(tokenId);
+        (bool ok, ) = _check(tokenId, vid, msg.sender, PermissionLevel.WRITE, currentEpoch);
         require(ok, "VPM: caller lacks WRITE");
 
         (, , address logic, ) = IBAP578(bap578).agentStates(tokenId);
@@ -161,6 +179,16 @@ contract VaultPermissionManagerReference is
 
         emit ActionForwarded(tokenId, vid, msg.sender, action);
         result = ILogicModuleForwardable(logic).handleAction(tokenId, action, data);
+    }
+
+    /// @notice Commit the current owner of `tokenId` into contract state.
+    /// @dev Anyone may call this. It advances the owner epoch if the token has
+    ///      changed hands since the contract last observed it, which permanently
+    ///      invalidates every grant issued under the previous owner. Off-chain
+    ///      indexers watching BAP-578 Transfer events can call this to close the
+    ///      window where a dormant token round-trips without any other VPM call.
+    function syncOwner(uint256 tokenId) external {
+        _syncEpoch(tokenId);
     }
 
     // ---- IVaultPermissionManager reads ------------------------------------
@@ -171,7 +199,7 @@ contract VaultPermissionManagerReference is
         address accessor,
         PermissionLevel minLevel
     ) external view returns (bool ok, uint256 expiry) {
-        return _check(tokenId, _vid(vaultId), accessor, minLevel);
+        return _check(tokenId, _vid(vaultId), accessor, minLevel, _currentEpoch(tokenId));
     }
 
     function canForward(
@@ -179,12 +207,20 @@ contract VaultPermissionManagerReference is
         string calldata vaultId,
         address accessor
     ) external view returns (bool) {
-        (bool ok, ) = _check(tokenId, _vid(vaultId), accessor, PermissionLevel.WRITE);
+        (bool ok, ) = _check(
+            tokenId, _vid(vaultId), accessor, PermissionLevel.WRITE, _currentEpoch(tokenId)
+        );
         return ok;
     }
 
     function vaultExists(uint256 tokenId, string calldata vaultId) external view returns (bool) {
         return _vaults[tokenId][_vid(vaultId)];
+    }
+
+    /// @notice Current owner epoch for a token, accounting for an owner change
+    ///         the contract has not yet committed to storage.
+    function ownerEpoch(uint256 tokenId) external view returns (uint256) {
+        return _currentEpoch(tokenId);
     }
 
     // ---- Internal ---------------------------------------------------------
@@ -193,21 +229,50 @@ contract VaultPermissionManagerReference is
         uint256 tokenId,
         bytes32 vid,
         address accessor,
-        PermissionLevel minLevel
+        PermissionLevel minLevel,
+        uint256 currentEpoch
     ) internal view returns (bool ok, uint256 expiry) {
         Grant storage g = _grants[tokenId][vid][accessor];
         if (!g.exists) return (false, 0);
         if (uint8(g.level) < uint8(minLevel)) return (false, g.expiry);
         if (g.expiry != 0 && block.timestamp > g.expiry) return (false, g.expiry);
-        // Auto-revoke: if the NFT changed hands since the grant, the grant is dead.
-        if (IBAP578(bap578).ownerOf(tokenId) != g.ownerAtGrant) return (false, g.expiry);
+        // Auto-revoke: a grant is dead once the token's owner epoch has moved.
+        if (g.epoch != currentEpoch) return (false, g.expiry);
         return (true, g.expiry);
     }
 
     function _authorizeGrantor(uint256 tokenId, bytes32 vid) internal view {
         if (IBAP578(bap578).ownerOf(tokenId) == msg.sender) return;
-        (bool isAdmin, ) = _check(tokenId, vid, msg.sender, PermissionLevel.ADMIN);
+        (bool isAdmin, ) = _check(
+            tokenId, vid, msg.sender, PermissionLevel.ADMIN, _currentEpoch(tokenId)
+        );
         require(isAdmin, "VPM: not owner or admin");
+    }
+
+    /// @dev Observe the current owner and advance the epoch if it changed.
+    ///      Returns the up-to-date epoch.
+    function _syncEpoch(uint256 tokenId) internal returns (uint256) {
+        address current = IBAP578(bap578).ownerOf(tokenId);
+        address lastSeen = _lastSeenOwner[tokenId];
+        if (lastSeen == address(0)) {
+            _lastSeenOwner[tokenId] = current;
+        } else if (lastSeen != current) {
+            uint256 next = _ownerEpoch[tokenId] + 1;
+            _ownerEpoch[tokenId] = next;
+            _lastSeenOwner[tokenId] = current;
+            emit OwnerEpochAdvanced(tokenId, lastSeen, current, next);
+        }
+        return _ownerEpoch[tokenId];
+    }
+
+    /// @dev View-only epoch: if the owner has changed since the last committed
+    ///      observation, the effective epoch is one ahead of stored state.
+    function _currentEpoch(uint256 tokenId) internal view returns (uint256) {
+        address lastSeen = _lastSeenOwner[tokenId];
+        if (lastSeen != address(0) && lastSeen != IBAP578(bap578).ownerOf(tokenId)) {
+            return _ownerEpoch[tokenId] + 1;
+        }
+        return _ownerEpoch[tokenId];
     }
 
     function _vid(string calldata vaultId) internal pure returns (bytes32) {

--- a/contracts/extensions/VaultPermissionManagerReference.sol
+++ b/contracts/extensions/VaultPermissionManagerReference.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+
+import "./IVaultPermissionManager.sol";
+
+/// @dev Minimal surface the VPM needs from BAP-578: owner-of and bound logic address.
+///      Matches `contracts/BAP578.sol` (agentStates returns a public tuple).
+interface IBAP578 {
+    function ownerOf(uint256 tokenId) external view returns (address);
+
+    function agentStates(uint256 tokenId)
+        external
+        view
+        returns (uint256 balance, bool active, address logicAddress, uint256 createdAt);
+}
+
+/// @dev The downstream-callable shape that VPM forwards into. Logic modules
+///      that want to be drivable through VPM implement this single function.
+interface ILogicModuleForwardable {
+    function handleAction(
+        uint256 tokenId,
+        string calldata action,
+        bytes calldata data
+    ) external returns (bytes memory);
+}
+
+/// @title VaultPermissionManagerReference
+/// @notice Reference UUPS implementation of IVaultPermissionManager.
+///
+///         Storage model: tokenId -> vaultIdHash -> grantee -> Grant.
+///         Vault IDs are user-supplied strings (kept for human readability in
+///         events), hashed to bytes32 for storage lookups.
+///
+///         Production deployments should add: pause guard, per-action policy
+///         hooks (see EXTENSION-README.md for the IPolicyGuard composition
+///         pattern), and indexer-friendly events.
+contract VaultPermissionManagerReference is
+    IVaultPermissionManager,
+    Initializable,
+    OwnableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable
+{
+    // ---- Storage ----------------------------------------------------------
+
+    struct Grant {
+        PermissionLevel level;
+        uint256 expiry;       // 0 = no expiry
+        address ownerAtGrant; // ownerOf(tokenId) at the time the grant was created
+        bool exists;
+    }
+
+    address public bap578;
+
+    // tokenId => vaultIdHash => exists
+    mapping(uint256 => mapping(bytes32 => bool)) private _vaults;
+
+    // tokenId => vaultIdHash => grantee => Grant
+    mapping(uint256 => mapping(bytes32 => mapping(address => Grant))) private _grants;
+
+    // Reserved storage for future upgrades.
+    uint256[50] private __gap;
+
+    // ---- Initializer ------------------------------------------------------
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address bap578_) public initializer {
+        require(bap578_ != address(0), "VPM: bap578 is zero");
+        __Ownable_init();
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+        bap578 = bap578_;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    // ---- Modifiers --------------------------------------------------------
+
+    modifier onlyTokenOwnerOrAdmin(uint256 tokenId, bytes32 vid) {
+        if (IBAP578(bap578).ownerOf(tokenId) != msg.sender) {
+            (bool ok, ) = _check(tokenId, vid, msg.sender, PermissionLevel.ADMIN);
+            require(ok, "VPM: not owner or admin");
+        }
+        _;
+    }
+
+    // ---- IVaultPermissionManager writes -----------------------------------
+
+    function createVault(
+        uint256 tokenId,
+        string calldata vaultId,
+        string calldata /*description*/
+    ) external {
+        require(IBAP578(bap578).ownerOf(tokenId) == msg.sender, "VPM: only NFT owner");
+        bytes32 vid = _vid(vaultId);
+        require(!_vaults[tokenId][vid], "VPM: vault exists");
+        _vaults[tokenId][vid] = true;
+        emit VaultCreated(tokenId, vid, vaultId, msg.sender);
+    }
+
+    function grantPermission(
+        uint256 tokenId,
+        string calldata vaultId,
+        address grantee,
+        PermissionLevel level,
+        uint256 expiry,
+        string calldata description
+    ) external {
+        require(grantee != address(0), "VPM: grantee zero");
+        require(level != PermissionLevel.NONE, "VPM: NONE; use revoke");
+        require(expiry == 0 || expiry > block.timestamp, "VPM: expiry in past");
+        bytes32 vid = _vid(vaultId);
+        require(_vaults[tokenId][vid], "VPM: no such vault");
+        _authorizeGrantor(tokenId, vid);
+
+        _grants[tokenId][vid][grantee] = Grant({
+            level: level,
+            expiry: expiry,
+            ownerAtGrant: IBAP578(bap578).ownerOf(tokenId),
+            exists: true
+        });
+        emit PermissionGranted(tokenId, vid, grantee, level, expiry, description);
+    }
+
+    function revokePermission(
+        uint256 tokenId,
+        string calldata vaultId,
+        address grantee
+    ) external {
+        bytes32 vid = _vid(vaultId);
+        require(_grants[tokenId][vid][grantee].exists, "VPM: no such grant");
+        _authorizeGrantor(tokenId, vid);
+
+        delete _grants[tokenId][vid][grantee];
+        emit PermissionRevoked(tokenId, vid, grantee);
+    }
+
+    function forwardHandleAction(
+        uint256 tokenId,
+        string calldata vaultId,
+        string calldata action,
+        bytes calldata data
+    ) external nonReentrant returns (bytes memory result) {
+        bytes32 vid = _vid(vaultId);
+        require(_vaults[tokenId][vid], "VPM: no such vault");
+
+        (bool ok, ) = _check(tokenId, vid, msg.sender, PermissionLevel.WRITE);
+        require(ok, "VPM: caller lacks WRITE");
+
+        (, , address logic, ) = IBAP578(bap578).agentStates(tokenId);
+        require(logic != address(0), "VPM: no logic bound");
+
+        emit ActionForwarded(tokenId, vid, msg.sender, action);
+        result = ILogicModuleForwardable(logic).handleAction(tokenId, action, data);
+    }
+
+    // ---- IVaultPermissionManager reads ------------------------------------
+
+    function checkPermission(
+        uint256 tokenId,
+        string calldata vaultId,
+        address accessor,
+        PermissionLevel minLevel
+    ) external view returns (bool ok, uint256 expiry) {
+        return _check(tokenId, _vid(vaultId), accessor, minLevel);
+    }
+
+    function canForward(
+        uint256 tokenId,
+        string calldata vaultId,
+        address accessor
+    ) external view returns (bool) {
+        (bool ok, ) = _check(tokenId, _vid(vaultId), accessor, PermissionLevel.WRITE);
+        return ok;
+    }
+
+    function vaultExists(uint256 tokenId, string calldata vaultId) external view returns (bool) {
+        return _vaults[tokenId][_vid(vaultId)];
+    }
+
+    // ---- Internal ---------------------------------------------------------
+
+    function _check(
+        uint256 tokenId,
+        bytes32 vid,
+        address accessor,
+        PermissionLevel minLevel
+    ) internal view returns (bool ok, uint256 expiry) {
+        Grant storage g = _grants[tokenId][vid][accessor];
+        if (!g.exists) return (false, 0);
+        if (uint8(g.level) < uint8(minLevel)) return (false, g.expiry);
+        if (g.expiry != 0 && block.timestamp > g.expiry) return (false, g.expiry);
+        // Auto-revoke: if the NFT changed hands since the grant, the grant is dead.
+        if (IBAP578(bap578).ownerOf(tokenId) != g.ownerAtGrant) return (false, g.expiry);
+        return (true, g.expiry);
+    }
+
+    function _authorizeGrantor(uint256 tokenId, bytes32 vid) internal view {
+        if (IBAP578(bap578).ownerOf(tokenId) == msg.sender) return;
+        (bool isAdmin, ) = _check(tokenId, vid, msg.sender, PermissionLevel.ADMIN);
+        require(isAdmin, "VPM: not owner or admin");
+    }
+
+    function _vid(string calldata vaultId) internal pure returns (bytes32) {
+        return keccak256(bytes(vaultId));
+    }
+}

--- a/contracts/extensions/VaultPermissionManagerReference.sol
+++ b/contracts/extensions/VaultPermissionManagerReference.sol
@@ -13,10 +13,9 @@ import "./IVaultPermissionManager.sol";
 interface IBAP578 {
     function ownerOf(uint256 tokenId) external view returns (address);
 
-    function agentStates(uint256 tokenId)
-        external
-        view
-        returns (uint256 balance, bool active, address logicAddress, uint256 createdAt);
+    function agentStates(
+        uint256 tokenId
+    ) external view returns (uint256 balance, bool active, address logicAddress, uint256 createdAt);
 }
 
 /// @dev The downstream-callable shape that VPM forwards into. Logic modules
@@ -58,7 +57,7 @@ contract VaultPermissionManagerReference is
     struct Grant {
         PermissionLevel level;
         uint256 expiry; // 0 = no expiry
-        uint256 epoch;  // owner epoch of the token when this grant was created
+        uint256 epoch; // owner epoch of the token when this grant was created
         bool exists;
     }
 
@@ -148,13 +147,10 @@ contract VaultPermissionManagerReference is
         emit PermissionGranted(tokenId, vid, grantee, level, expiry, description);
     }
 
-    function revokePermission(
-        uint256 tokenId,
-        string calldata vaultId,
-        address grantee
-    ) external {
+    function revokePermission(uint256 tokenId, string calldata vaultId, address grantee) external {
         bytes32 vid = _vid(vaultId);
         require(_grants[tokenId][vid][grantee].exists, "VPM: no such grant");
+        _syncEpoch(tokenId);
         _authorizeGrantor(tokenId, vid);
 
         delete _grants[tokenId][vid][grantee];
@@ -208,7 +204,11 @@ contract VaultPermissionManagerReference is
         address accessor
     ) external view returns (bool) {
         (bool ok, ) = _check(
-            tokenId, _vid(vaultId), accessor, PermissionLevel.WRITE, _currentEpoch(tokenId)
+            tokenId,
+            _vid(vaultId),
+            accessor,
+            PermissionLevel.WRITE,
+            _currentEpoch(tokenId)
         );
         return ok;
     }
@@ -244,7 +244,11 @@ contract VaultPermissionManagerReference is
     function _authorizeGrantor(uint256 tokenId, bytes32 vid) internal view {
         if (IBAP578(bap578).ownerOf(tokenId) == msg.sender) return;
         (bool isAdmin, ) = _check(
-            tokenId, vid, msg.sender, PermissionLevel.ADMIN, _currentEpoch(tokenId)
+            tokenId,
+            vid,
+            msg.sender,
+            PermissionLevel.ADMIN,
+            _currentEpoch(tokenId)
         );
         require(isAdmin, "VPM: not owner or admin");
     }

--- a/contracts/mocks/MockBAP578ForVPM.sol
+++ b/contracts/mocks/MockBAP578ForVPM.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Minimal mock of the BAP578 surface that VaultPermissionManagerReference reads.
+///         Used only by VaultPermissionManager.test.js. Not for production.
+contract MockBAP578ForVPM {
+    mapping(uint256 => address) public ownerOf;
+
+    struct AgentState {
+        uint256 balance;
+        bool active;
+        address logicAddress;
+        uint256 createdAt;
+    }
+
+    mapping(uint256 => AgentState) public agentStates;
+
+    function mint(uint256 tokenId, address to, address logicAddress) external {
+        ownerOf[tokenId] = to;
+        agentStates[tokenId] = AgentState({
+            balance: 0,
+            active: true,
+            logicAddress: logicAddress,
+            createdAt: block.timestamp
+        });
+    }
+
+    function setLogic(uint256 tokenId, address logicAddress) external {
+        agentStates[tokenId].logicAddress = logicAddress;
+    }
+
+    function transfer(uint256 tokenId, address to) external {
+        ownerOf[tokenId] = to;
+    }
+}

--- a/contracts/mocks/MockLogicModule.sol
+++ b/contracts/mocks/MockLogicModule.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Minimal mock implementing the ILogicModuleForwardable surface.
+///         Records the last call and lets tests assert on (tokenId, action, data).
+contract MockLogicModule {
+    uint256 public lastTokenId;
+    string public lastAction;
+    bytes public lastData;
+    address public lastCaller;
+    bool public revertNext;
+    string public revertMessage;
+
+    function setRevertNext(bool on, string calldata message) external {
+        revertNext = on;
+        revertMessage = message;
+    }
+
+    function handleAction(
+        uint256 tokenId,
+        string calldata action,
+        bytes calldata data
+    ) external returns (bytes memory) {
+        if (revertNext) {
+            revertNext = false;
+            revert(bytes(revertMessage).length == 0 ? "MockLogicModule: forced revert" : revertMessage);
+        }
+        lastTokenId = tokenId;
+        lastAction = action;
+        lastData = data;
+        lastCaller = msg.sender;
+        return abi.encode(true);
+    }
+}

--- a/contracts/mocks/MockLogicModule.sol
+++ b/contracts/mocks/MockLogicModule.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import { ILogicModuleForwardable } from "../extensions/VaultPermissionManagerReference.sol";
+
 /// @notice Minimal mock implementing the ILogicModuleForwardable surface.
 ///         Records the last call and lets tests assert on (tokenId, action, data).
-contract MockLogicModule {
+contract MockLogicModule is ILogicModuleForwardable {
     uint256 public lastTokenId;
     string public lastAction;
     bytes public lastData;
@@ -20,10 +22,12 @@ contract MockLogicModule {
         uint256 tokenId,
         string calldata action,
         bytes calldata data
-    ) external returns (bytes memory) {
+    ) external override returns (bytes memory) {
         if (revertNext) {
             revertNext = false;
-            revert(bytes(revertMessage).length == 0 ? "MockLogicModule: forced revert" : revertMessage);
+            revert(
+                bytes(revertMessage).length == 0 ? "MockLogicModule: forced revert" : revertMessage
+            );
         }
         lastTokenId = tokenId;
         lastAction = action;

--- a/test/VaultPermissionManager.test.js
+++ b/test/VaultPermissionManager.test.js
@@ -107,6 +107,66 @@ describe('VaultPermissionManager Extension', function () {
                 ),
             ).to.be.revertedWith('VPM: expiry in past');
         });
+
+        it('rejects granting to self', async function () {
+            await expect(
+                vpm.connect(owner).grantPermission(
+                    TOKEN_ID, VAULT_ID, owner.address, WRITE, 0, '',
+                ),
+            ).to.be.revertedWith('VPM: cannot grant to self');
+        });
+    });
+
+    describe('ADMIN tier restrictions', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+        });
+
+        it('lets the NFT owner grant ADMIN', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
+            );
+            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN);
+            expect(ok).to.equal(true);
+        });
+
+        it('forbids an ADMIN from granting the ADMIN tier', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
+            );
+            await expect(
+                vpm.connect(admin).grantPermission(
+                    TOKEN_ID, VAULT_ID, stranger.address, ADMIN, 0, '',
+                ),
+            ).to.be.revertedWith('VPM: only owner grants ADMIN');
+        });
+
+        it('lets an ADMIN grant READ and WRITE', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
+            );
+            await vpm.connect(admin).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            await vpm.connect(admin).grantPermission(
+                TOKEN_ID, VAULT_ID, stranger.address, READ, 0, '',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+        });
+
+        it('blocks an ADMIN from self-renewing (grant-to-self is rejected first)', async function () {
+            const shortExpiry = (await ethers.provider.getBlock('latest')).timestamp + 60;
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, ADMIN, shortExpiry, '',
+            );
+            // The ADMIN cannot extend its own grant: grant-to-self is rejected,
+            // and even without that, ADMIN-tier grants are owner-only.
+            await expect(
+                vpm.connect(admin).grantPermission(
+                    TOKEN_ID, VAULT_ID, admin.address, ADMIN, shortExpiry + 100000, '',
+                ),
+            ).to.be.revertedWith('VPM: cannot grant to self');
+        });
     });
 
     describe('revokePermission', function () {
@@ -360,15 +420,34 @@ describe('VaultPermissionManager Extension', function () {
             expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
         });
 
-        // Documented edge case: if the NFT returns to the original owner and no
-        // explicit revoke happened, the stale grant reactivates because its
-        // ownerAtGrant field matches the current owner again. Owners who want
-        // belt-and-braces protection should revoke explicitly before re-acquiring.
-        it('reactivates a stale grant if the NFT returns to the original granter', async function () {
+        it('does NOT reactivate when the contract observed the intermediate owner', async function () {
+            await bap578Mock.transfer(TOKEN_ID, stranger.address);
+            // Anyone (here the new owner) commits the owner change, advancing the epoch.
+            await vpm.connect(stranger).syncOwner(TOKEN_ID);
+            await bap578Mock.transfer(TOKEN_ID, owner.address);
+            // The grant was stamped at epoch 0; the epoch is now 2, so it stays dead.
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+        });
+
+        // Documented residual edge case: if the NFT round-trips owners with NO
+        // VPM call at all in between, the contract never observed the change, so
+        // the epoch never advanced and the original grant reactivates. Closing
+        // this fully needs a transfer hook on BAP-578; an off-chain indexer
+        // calling syncOwner on Transfer events also closes it in practice.
+        it('residual: reactivates only on a fully unobserved owner round-trip', async function () {
             await bap578Mock.transfer(TOKEN_ID, stranger.address);
             expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
             await bap578Mock.transfer(TOKEN_ID, owner.address);
             expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+        });
+
+        it('exposes the owner epoch and advances it on observed transfers', async function () {
+            expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(0);
+            await bap578Mock.transfer(TOKEN_ID, stranger.address);
+            // View call already reflects the pending change.
+            expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(1);
+            await vpm.connect(stranger).syncOwner(TOKEN_ID);
+            expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(1);
         });
     });
 });

--- a/test/VaultPermissionManager.test.js
+++ b/test/VaultPermissionManager.test.js
@@ -1,0 +1,374 @@
+const { expect } = require('chai');
+const { ethers, upgrades } = require('hardhat');
+
+describe('VaultPermissionManager Extension', function () {
+    const VAULT_ID = 'default';
+    const TOKEN_ID = 1;
+
+    // PermissionLevel enum: NONE=0, READ=1, WRITE=2, ADMIN=3
+    const NONE = 0;
+    const READ = 1;
+    const WRITE = 2;
+    const ADMIN = 3;
+
+    let owner, operator, admin, stranger;
+    let bap578Mock, logic, vpm;
+
+    beforeEach(async function () {
+        [owner, operator, admin, stranger] = await ethers.getSigners();
+
+        const Mock = await ethers.getContractFactory('MockBAP578ForVPM');
+        bap578Mock = await Mock.deploy();
+        await bap578Mock.deployed();
+
+        const Logic = await ethers.getContractFactory('MockLogicModule');
+        logic = await Logic.deploy();
+        await logic.deployed();
+
+        await bap578Mock.mint(TOKEN_ID, owner.address, logic.address);
+
+        const VPM = await ethers.getContractFactory('VaultPermissionManagerReference');
+        vpm = await upgrades.deployProxy(VPM, [bap578Mock.address], {
+            initializer: 'initialize',
+            kind: 'uups',
+        });
+        await vpm.deployed();
+    });
+
+    describe('createVault', function () {
+        it('lets the NFT owner create a vault', async function () {
+            await expect(vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, 'session memory'))
+                .to.emit(vpm, 'VaultCreated');
+            expect(await vpm.vaultExists(TOKEN_ID, VAULT_ID)).to.equal(true);
+        });
+
+        it('rejects non-owner creation', async function () {
+            await expect(
+                vpm.connect(stranger).createVault(TOKEN_ID, VAULT_ID, ''),
+            ).to.be.revertedWith('VPM: only NFT owner');
+        });
+
+        it('rejects duplicate vault', async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+            await expect(
+                vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, ''),
+            ).to.be.revertedWith('VPM: vault exists');
+        });
+    });
+
+    describe('grantPermission', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+        });
+
+        it('lets the NFT owner grant WRITE to an operator', async function () {
+            await expect(
+                vpm.connect(owner).grantPermission(
+                    TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, 'trader bot',
+                ),
+            ).to.emit(vpm, 'PermissionGranted');
+
+            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE);
+            expect(ok).to.equal(true);
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+        });
+
+        it('lets an ADMIN grant further permissions', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
+            );
+            await vpm.connect(admin).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+        });
+
+        it('rejects a non-owner non-admin grantor', async function () {
+            await expect(
+                vpm.connect(stranger).grantPermission(
+                    TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+                ),
+            ).to.be.revertedWith('VPM: not owner or admin');
+        });
+
+        it('rejects NONE as a grant level', async function () {
+            await expect(
+                vpm.connect(owner).grantPermission(
+                    TOKEN_ID, VAULT_ID, operator.address, NONE, 0, '',
+                ),
+            ).to.be.revertedWith('VPM: NONE; use revoke');
+        });
+
+        it('rejects an expiry in the past', async function () {
+            const past = (await ethers.provider.getBlock('latest')).timestamp - 60;
+            await expect(
+                vpm.connect(owner).grantPermission(
+                    TOKEN_ID, VAULT_ID, operator.address, WRITE, past, '',
+                ),
+            ).to.be.revertedWith('VPM: expiry in past');
+        });
+    });
+
+    describe('revokePermission', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+        });
+
+        it('lets the NFT owner revoke', async function () {
+            await expect(
+                vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, operator.address),
+            ).to.emit(vpm, 'PermissionRevoked');
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+        });
+
+        it('rejects revoking a grant that does not exist', async function () {
+            await expect(
+                vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, stranger.address),
+            ).to.be.revertedWith('VPM: no such grant');
+        });
+    });
+
+    describe('forwardHandleAction', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+        });
+
+        it('forwards to the bound logic when caller has WRITE', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            const data = ethers.utils.defaultAbiCoder.encode(['uint256'], [42]);
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', data),
+            ).to.emit(vpm, 'ActionForwarded');
+
+            expect(await logic.lastTokenId()).to.equal(TOKEN_ID);
+            expect(await logic.lastAction()).to.equal('buy_token');
+            expect(await logic.lastCaller()).to.equal(vpm.address);
+        });
+
+        it('reverts when caller has no grant', async function () {
+            await expect(
+                vpm.connect(stranger).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+            ).to.be.revertedWith('VPM: caller lacks WRITE');
+        });
+
+        it('reverts when caller has only READ', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, READ, 0, '',
+            );
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+            ).to.be.revertedWith('VPM: caller lacks WRITE');
+        });
+
+        it('reverts when the grant has expired', async function () {
+            const expiry = (await ethers.provider.getBlock('latest')).timestamp + 30;
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, expiry, '',
+            );
+            await ethers.provider.send('evm_increaseTime', [60]);
+            await ethers.provider.send('evm_mine');
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+            ).to.be.revertedWith('VPM: caller lacks WRITE');
+        });
+
+        it('reverts when no logic is bound', async function () {
+            await bap578Mock.setLogic(TOKEN_ID, ethers.constants.AddressZero);
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+            ).to.be.revertedWith('VPM: no logic bound');
+        });
+
+        it('bubbles up the logic module revert reason', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            await logic.setRevertNext(true, 'logic: insufficient balance');
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+            ).to.be.revertedWith('logic: insufficient balance');
+        });
+    });
+
+    describe('isolation between grants', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+        });
+
+        it('keeps two grantees independent on the same vault', async function () {
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, READ, 0, '',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, admin.address)).to.equal(false);
+
+            await vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, operator.address);
+            // Revoking operator should not touch admin's grant.
+            const [adminOk] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, admin.address, READ);
+            expect(adminOk).to.equal(true);
+        });
+
+        it('isolates grants across vaults on the same token', async function () {
+            const OTHER = 'social';
+            await vpm.connect(owner).createVault(TOKEN_ID, OTHER, '');
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+            expect(await vpm.canForward(TOKEN_ID, OTHER, operator.address)).to.equal(false);
+        });
+
+        it('isolates grants across tokens', async function () {
+            await bap578Mock.mint(2, owner.address, logic.address);
+            await vpm.connect(owner).createVault(2, VAULT_ID, '');
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+            expect(await vpm.canForward(2, VAULT_ID, operator.address)).to.equal(false);
+        });
+    });
+
+    describe('re-grant semantics', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, READ, 0, '',
+            );
+        });
+
+        it('overwrites an existing grant with a new tier', async function () {
+            // Bump from READ to ADMIN by re-granting.
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, ADMIN, 0, '',
+            );
+            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, ADMIN);
+            expect(ok).to.equal(true);
+        });
+
+        it('re-grants cleanly after the NFT changed hands', async function () {
+            await bap578Mock.transfer(TOKEN_ID, stranger.address);
+            // Old (auto-revoked) READ grant is replaced by a fresh WRITE under the new owner.
+            await vpm.connect(stranger).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+        });
+    });
+
+    describe('input validation', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+        });
+
+        it('rejects zero-address grantee', async function () {
+            await expect(
+                vpm.connect(owner).grantPermission(
+                    TOKEN_ID, VAULT_ID, ethers.constants.AddressZero, WRITE, 0, '',
+                ),
+            ).to.be.revertedWith('VPM: grantee zero');
+        });
+
+        it('rejects grants on a non-existent vault', async function () {
+            await expect(
+                vpm.connect(owner).grantPermission(
+                    TOKEN_ID, 'ghost', operator.address, WRITE, 0, '',
+                ),
+            ).to.be.revertedWith('VPM: no such vault');
+        });
+
+        it('rejects forwards on a non-existent vault', async function () {
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, 'ghost', 'buy_token', '0x'),
+            ).to.be.revertedWith('VPM: no such vault');
+        });
+    });
+
+    describe('initialization + upgrade auth', function () {
+        it('rejects a second initialize', async function () {
+            await expect(vpm.initialize(bap578Mock.address)).to.be.reverted;
+        });
+
+        it('only the owner can authorize an upgrade', async function () {
+            const VPM = await ethers.getContractFactory('VaultPermissionManagerReference');
+            // Stranger attempting upgrade should revert.
+            const newImpl = await VPM.deploy();
+            await newImpl.deployed();
+            // The OwnableUpgradeable owner is the deployer of the proxy (this test runner).
+            // We simulate a non-owner upgrade attempt via the raw upgradeTo selector.
+            const ifaceFragment = ['function upgradeTo(address)'];
+            const proxyAsUUPS = new ethers.Contract(vpm.address, ifaceFragment, stranger);
+            await expect(proxyAsUUPS.upgradeTo(newImpl.address)).to.be.reverted;
+        });
+    });
+
+    describe('forwardHandleAction return value', function () {
+        it('returns whatever bytes the logic module returns', async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+            // Static-call to read the return value (mock returns abi.encode(true)).
+            const result = await vpm.connect(operator).callStatic.forwardHandleAction(
+                TOKEN_ID, VAULT_ID, 'check_balance', '0x',
+            );
+            const [decoded] = ethers.utils.defaultAbiCoder.decode(['bool'], result);
+            expect(decoded).to.equal(true);
+        });
+    });
+
+    describe('auto-revoke on NFT transfer', function () {
+        beforeEach(async function () {
+            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+            await vpm.connect(owner).grantPermission(
+                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
+            );
+        });
+
+        it('invalidates the grant the moment the NFT changes hands', async function () {
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+            await bap578Mock.transfer(TOKEN_ID, stranger.address);
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+
+            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE);
+            expect(ok).to.equal(false);
+
+            await expect(
+                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+            ).to.be.revertedWith('VPM: caller lacks WRITE');
+        });
+
+        it('lets the new owner issue their own grants on the existing vault', async function () {
+            await bap578Mock.transfer(TOKEN_ID, stranger.address);
+            // Old grant is invalid; new owner grants a fresh one.
+            await vpm.connect(stranger).grantPermission(
+                TOKEN_ID, VAULT_ID, admin.address, WRITE, 0, 'new owner bot',
+            );
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, admin.address)).to.equal(true);
+            // Old operator stays revoked.
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+        });
+
+        // Documented edge case: if the NFT returns to the original owner and no
+        // explicit revoke happened, the stale grant reactivates because its
+        // ownerAtGrant field matches the current owner again. Owners who want
+        // belt-and-braces protection should revoke explicitly before re-acquiring.
+        it('reactivates a stale grant if the NFT returns to the original granter', async function () {
+            await bap578Mock.transfer(TOKEN_ID, stranger.address);
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+            await bap578Mock.transfer(TOKEN_ID, owner.address);
+            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+        });
+    });
+});

--- a/test/VaultPermissionManager.test.js
+++ b/test/VaultPermissionManager.test.js
@@ -2,452 +2,409 @@ const { expect } = require('chai');
 const { ethers, upgrades } = require('hardhat');
 
 describe('VaultPermissionManager Extension', function () {
-    const VAULT_ID = 'default';
-    const TOKEN_ID = 1;
+  const VAULT_ID = 'default';
+  const TOKEN_ID = 1;
 
-    // PermissionLevel enum: NONE=0, READ=1, WRITE=2, ADMIN=3
-    const NONE = 0;
-    const READ = 1;
-    const WRITE = 2;
-    const ADMIN = 3;
+  // PermissionLevel enum: NONE=0, READ=1, WRITE=2, ADMIN=3
+  const NONE = 0;
+  const READ = 1;
+  const WRITE = 2;
+  const ADMIN = 3;
 
-    let owner, operator, admin, stranger;
-    let bap578Mock, logic, vpm;
+  let owner, operator, admin, stranger;
+  let bap578Mock, logic, vpm;
 
+  beforeEach(async function () {
+    [owner, operator, admin, stranger] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory('MockBAP578ForVPM');
+    bap578Mock = await Mock.deploy();
+    await bap578Mock.deployed();
+
+    const Logic = await ethers.getContractFactory('MockLogicModule');
+    logic = await Logic.deploy();
+    await logic.deployed();
+
+    await bap578Mock.mint(TOKEN_ID, owner.address, logic.address);
+
+    const VPM = await ethers.getContractFactory('VaultPermissionManagerReference');
+    vpm = await upgrades.deployProxy(VPM, [bap578Mock.address], {
+      initializer: 'initialize',
+      kind: 'uups',
+    });
+    await vpm.deployed();
+  });
+
+  describe('createVault', function () {
+    it('lets the NFT owner create a vault', async function () {
+      await expect(vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, 'session memory')).to.emit(
+        vpm,
+        'VaultCreated',
+      );
+      expect(await vpm.vaultExists(TOKEN_ID, VAULT_ID)).to.equal(true);
+    });
+
+    it('rejects non-owner creation', async function () {
+      await expect(vpm.connect(stranger).createVault(TOKEN_ID, VAULT_ID, '')).to.be.revertedWith(
+        'VPM: only NFT owner',
+      );
+    });
+
+    it('rejects duplicate vault', async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+      await expect(vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '')).to.be.revertedWith(
+        'VPM: vault exists',
+      );
+    });
+  });
+
+  describe('grantPermission', function () {
     beforeEach(async function () {
-        [owner, operator, admin, stranger] = await ethers.getSigners();
-
-        const Mock = await ethers.getContractFactory('MockBAP578ForVPM');
-        bap578Mock = await Mock.deploy();
-        await bap578Mock.deployed();
-
-        const Logic = await ethers.getContractFactory('MockLogicModule');
-        logic = await Logic.deploy();
-        await logic.deployed();
-
-        await bap578Mock.mint(TOKEN_ID, owner.address, logic.address);
-
-        const VPM = await ethers.getContractFactory('VaultPermissionManagerReference');
-        vpm = await upgrades.deployProxy(VPM, [bap578Mock.address], {
-            initializer: 'initialize',
-            kind: 'uups',
-        });
-        await vpm.deployed();
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
     });
 
-    describe('createVault', function () {
-        it('lets the NFT owner create a vault', async function () {
-            await expect(vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, 'session memory'))
-                .to.emit(vpm, 'VaultCreated');
-            expect(await vpm.vaultExists(TOKEN_ID, VAULT_ID)).to.equal(true);
-        });
+    it('lets the NFT owner grant WRITE to an operator', async function () {
+      await expect(
+        vpm
+          .connect(owner)
+          .grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, 'trader bot'),
+      ).to.emit(vpm, 'PermissionGranted');
 
-        it('rejects non-owner creation', async function () {
-            await expect(
-                vpm.connect(stranger).createVault(TOKEN_ID, VAULT_ID, ''),
-            ).to.be.revertedWith('VPM: only NFT owner');
-        });
-
-        it('rejects duplicate vault', async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-            await expect(
-                vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, ''),
-            ).to.be.revertedWith('VPM: vault exists');
-        });
+      const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE);
+      expect(ok).to.equal(true);
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
     });
 
-    describe('grantPermission', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-        });
-
-        it('lets the NFT owner grant WRITE to an operator', async function () {
-            await expect(
-                vpm.connect(owner).grantPermission(
-                    TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, 'trader bot',
-                ),
-            ).to.emit(vpm, 'PermissionGranted');
-
-            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE);
-            expect(ok).to.equal(true);
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-        });
-
-        it('lets an ADMIN grant further permissions', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
-            );
-            await vpm.connect(admin).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-        });
-
-        it('rejects a non-owner non-admin grantor', async function () {
-            await expect(
-                vpm.connect(stranger).grantPermission(
-                    TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-                ),
-            ).to.be.revertedWith('VPM: not owner or admin');
-        });
-
-        it('rejects NONE as a grant level', async function () {
-            await expect(
-                vpm.connect(owner).grantPermission(
-                    TOKEN_ID, VAULT_ID, operator.address, NONE, 0, '',
-                ),
-            ).to.be.revertedWith('VPM: NONE; use revoke');
-        });
-
-        it('rejects an expiry in the past', async function () {
-            const past = (await ethers.provider.getBlock('latest')).timestamp - 60;
-            await expect(
-                vpm.connect(owner).grantPermission(
-                    TOKEN_ID, VAULT_ID, operator.address, WRITE, past, '',
-                ),
-            ).to.be.revertedWith('VPM: expiry in past');
-        });
-
-        it('rejects granting to self', async function () {
-            await expect(
-                vpm.connect(owner).grantPermission(
-                    TOKEN_ID, VAULT_ID, owner.address, WRITE, 0, '',
-                ),
-            ).to.be.revertedWith('VPM: cannot grant to self');
-        });
+    it('lets an ADMIN grant further permissions', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '');
+      await vpm.connect(admin).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
     });
 
-    describe('ADMIN tier restrictions', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-        });
-
-        it('lets the NFT owner grant ADMIN', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
-            );
-            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN);
-            expect(ok).to.equal(true);
-        });
-
-        it('forbids an ADMIN from granting the ADMIN tier', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
-            );
-            await expect(
-                vpm.connect(admin).grantPermission(
-                    TOKEN_ID, VAULT_ID, stranger.address, ADMIN, 0, '',
-                ),
-            ).to.be.revertedWith('VPM: only owner grants ADMIN');
-        });
-
-        it('lets an ADMIN grant READ and WRITE', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '',
-            );
-            await vpm.connect(admin).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            await vpm.connect(admin).grantPermission(
-                TOKEN_ID, VAULT_ID, stranger.address, READ, 0, '',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-        });
-
-        it('blocks an ADMIN from self-renewing (grant-to-self is rejected first)', async function () {
-            const shortExpiry = (await ethers.provider.getBlock('latest')).timestamp + 60;
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, ADMIN, shortExpiry, '',
-            );
-            // The ADMIN cannot extend its own grant: grant-to-self is rejected,
-            // and even without that, ADMIN-tier grants are owner-only.
-            await expect(
-                vpm.connect(admin).grantPermission(
-                    TOKEN_ID, VAULT_ID, admin.address, ADMIN, shortExpiry + 100000, '',
-                ),
-            ).to.be.revertedWith('VPM: cannot grant to self');
-        });
+    it('rejects a non-owner non-admin grantor', async function () {
+      await expect(
+        vpm.connect(stranger).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, ''),
+      ).to.be.revertedWith('VPM: not owner or admin');
     });
 
-    describe('revokePermission', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-        });
-
-        it('lets the NFT owner revoke', async function () {
-            await expect(
-                vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, operator.address),
-            ).to.emit(vpm, 'PermissionRevoked');
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
-        });
-
-        it('rejects revoking a grant that does not exist', async function () {
-            await expect(
-                vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, stranger.address),
-            ).to.be.revertedWith('VPM: no such grant');
-        });
+    it('rejects NONE as a grant level', async function () {
+      await expect(
+        vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, NONE, 0, ''),
+      ).to.be.revertedWith('VPM: NONE; use revoke');
     });
 
-    describe('forwardHandleAction', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-        });
-
-        it('forwards to the bound logic when caller has WRITE', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            const data = ethers.utils.defaultAbiCoder.encode(['uint256'], [42]);
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', data),
-            ).to.emit(vpm, 'ActionForwarded');
-
-            expect(await logic.lastTokenId()).to.equal(TOKEN_ID);
-            expect(await logic.lastAction()).to.equal('buy_token');
-            expect(await logic.lastCaller()).to.equal(vpm.address);
-        });
-
-        it('reverts when caller has no grant', async function () {
-            await expect(
-                vpm.connect(stranger).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
-            ).to.be.revertedWith('VPM: caller lacks WRITE');
-        });
-
-        it('reverts when caller has only READ', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, READ, 0, '',
-            );
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
-            ).to.be.revertedWith('VPM: caller lacks WRITE');
-        });
-
-        it('reverts when the grant has expired', async function () {
-            const expiry = (await ethers.provider.getBlock('latest')).timestamp + 30;
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, expiry, '',
-            );
-            await ethers.provider.send('evm_increaseTime', [60]);
-            await ethers.provider.send('evm_mine');
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
-            ).to.be.revertedWith('VPM: caller lacks WRITE');
-        });
-
-        it('reverts when no logic is bound', async function () {
-            await bap578Mock.setLogic(TOKEN_ID, ethers.constants.AddressZero);
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
-            ).to.be.revertedWith('VPM: no logic bound');
-        });
-
-        it('bubbles up the logic module revert reason', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            await logic.setRevertNext(true, 'logic: insufficient balance');
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
-            ).to.be.revertedWith('logic: insufficient balance');
-        });
+    it('rejects an expiry in the past', async function () {
+      const past = (await ethers.provider.getBlock('latest')).timestamp - 60;
+      await expect(
+        vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, past, ''),
+      ).to.be.revertedWith('VPM: expiry in past');
     });
 
-    describe('isolation between grants', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-        });
+    it('rejects granting to self', async function () {
+      await expect(
+        vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, owner.address, WRITE, 0, ''),
+      ).to.be.revertedWith('VPM: cannot grant to self');
+    });
+  });
 
-        it('keeps two grantees independent on the same vault', async function () {
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, READ, 0, '',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, admin.address)).to.equal(false);
-
-            await vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, operator.address);
-            // Revoking operator should not touch admin's grant.
-            const [adminOk] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, admin.address, READ);
-            expect(adminOk).to.equal(true);
-        });
-
-        it('isolates grants across vaults on the same token', async function () {
-            const OTHER = 'social';
-            await vpm.connect(owner).createVault(TOKEN_ID, OTHER, '');
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-            expect(await vpm.canForward(TOKEN_ID, OTHER, operator.address)).to.equal(false);
-        });
-
-        it('isolates grants across tokens', async function () {
-            await bap578Mock.mint(2, owner.address, logic.address);
-            await vpm.connect(owner).createVault(2, VAULT_ID, '');
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-            expect(await vpm.canForward(2, VAULT_ID, operator.address)).to.equal(false);
-        });
+  describe('ADMIN tier restrictions', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
     });
 
-    describe('re-grant semantics', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, READ, 0, '',
-            );
-        });
-
-        it('overwrites an existing grant with a new tier', async function () {
-            // Bump from READ to ADMIN by re-granting.
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, ADMIN, 0, '',
-            );
-            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, ADMIN);
-            expect(ok).to.equal(true);
-        });
-
-        it('re-grants cleanly after the NFT changed hands', async function () {
-            await bap578Mock.transfer(TOKEN_ID, stranger.address);
-            // Old (auto-revoked) READ grant is replaced by a fresh WRITE under the new owner.
-            await vpm.connect(stranger).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-        });
+    it('lets the NFT owner grant ADMIN', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '');
+      const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN);
+      expect(ok).to.equal(true);
     });
 
-    describe('input validation', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-        });
-
-        it('rejects zero-address grantee', async function () {
-            await expect(
-                vpm.connect(owner).grantPermission(
-                    TOKEN_ID, VAULT_ID, ethers.constants.AddressZero, WRITE, 0, '',
-                ),
-            ).to.be.revertedWith('VPM: grantee zero');
-        });
-
-        it('rejects grants on a non-existent vault', async function () {
-            await expect(
-                vpm.connect(owner).grantPermission(
-                    TOKEN_ID, 'ghost', operator.address, WRITE, 0, '',
-                ),
-            ).to.be.revertedWith('VPM: no such vault');
-        });
-
-        it('rejects forwards on a non-existent vault', async function () {
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, 'ghost', 'buy_token', '0x'),
-            ).to.be.revertedWith('VPM: no such vault');
-        });
+    it('forbids an ADMIN from granting the ADMIN tier', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '');
+      await expect(
+        vpm.connect(admin).grantPermission(TOKEN_ID, VAULT_ID, stranger.address, ADMIN, 0, ''),
+      ).to.be.revertedWith('VPM: only owner grants ADMIN');
     });
 
-    describe('initialization + upgrade auth', function () {
-        it('rejects a second initialize', async function () {
-            await expect(vpm.initialize(bap578Mock.address)).to.be.reverted;
-        });
-
-        it('only the owner can authorize an upgrade', async function () {
-            const VPM = await ethers.getContractFactory('VaultPermissionManagerReference');
-            // Stranger attempting upgrade should revert.
-            const newImpl = await VPM.deploy();
-            await newImpl.deployed();
-            // The OwnableUpgradeable owner is the deployer of the proxy (this test runner).
-            // We simulate a non-owner upgrade attempt via the raw upgradeTo selector.
-            const ifaceFragment = ['function upgradeTo(address)'];
-            const proxyAsUUPS = new ethers.Contract(vpm.address, ifaceFragment, stranger);
-            await expect(proxyAsUUPS.upgradeTo(newImpl.address)).to.be.reverted;
-        });
+    it('lets an ADMIN grant READ and WRITE', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '');
+      await vpm.connect(admin).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      await vpm.connect(admin).grantPermission(TOKEN_ID, VAULT_ID, stranger.address, READ, 0, '');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
     });
 
-    describe('forwardHandleAction return value', function () {
-        it('returns whatever bytes the logic module returns', async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-            // Static-call to read the return value (mock returns abi.encode(true)).
-            const result = await vpm.connect(operator).callStatic.forwardHandleAction(
-                TOKEN_ID, VAULT_ID, 'check_balance', '0x',
-            );
-            const [decoded] = ethers.utils.defaultAbiCoder.decode(['bool'], result);
-            expect(decoded).to.equal(true);
-        });
+    it('blocks an ADMIN from self-renewing (grant-to-self is rejected first)', async function () {
+      const shortExpiry = (await ethers.provider.getBlock('latest')).timestamp + 60;
+      await vpm
+        .connect(owner)
+        .grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, shortExpiry, '');
+      // The ADMIN cannot extend its own grant: grant-to-self is rejected,
+      // and even without that, ADMIN-tier grants are owner-only.
+      await expect(
+        vpm
+          .connect(admin)
+          .grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, shortExpiry + 100000, ''),
+      ).to.be.revertedWith('VPM: cannot grant to self');
+    });
+  });
+
+  describe('revokePermission', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
     });
 
-    describe('auto-revoke on NFT transfer', function () {
-        beforeEach(async function () {
-            await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
-            await vpm.connect(owner).grantPermission(
-                TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '',
-            );
-        });
-
-        it('invalidates the grant the moment the NFT changes hands', async function () {
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-            await bap578Mock.transfer(TOKEN_ID, stranger.address);
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
-
-            const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE);
-            expect(ok).to.equal(false);
-
-            await expect(
-                vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
-            ).to.be.revertedWith('VPM: caller lacks WRITE');
-        });
-
-        it('lets the new owner issue their own grants on the existing vault', async function () {
-            await bap578Mock.transfer(TOKEN_ID, stranger.address);
-            // Old grant is invalid; new owner grants a fresh one.
-            await vpm.connect(stranger).grantPermission(
-                TOKEN_ID, VAULT_ID, admin.address, WRITE, 0, 'new owner bot',
-            );
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, admin.address)).to.equal(true);
-            // Old operator stays revoked.
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
-        });
-
-        it('does NOT reactivate when the contract observed the intermediate owner', async function () {
-            await bap578Mock.transfer(TOKEN_ID, stranger.address);
-            // Anyone (here the new owner) commits the owner change, advancing the epoch.
-            await vpm.connect(stranger).syncOwner(TOKEN_ID);
-            await bap578Mock.transfer(TOKEN_ID, owner.address);
-            // The grant was stamped at epoch 0; the epoch is now 2, so it stays dead.
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
-        });
-
-        // Documented residual edge case: if the NFT round-trips owners with NO
-        // VPM call at all in between, the contract never observed the change, so
-        // the epoch never advanced and the original grant reactivates. Closing
-        // this fully needs a transfer hook on BAP-578; an off-chain indexer
-        // calling syncOwner on Transfer events also closes it in practice.
-        it('residual: reactivates only on a fully unobserved owner round-trip', async function () {
-            await bap578Mock.transfer(TOKEN_ID, stranger.address);
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
-            await bap578Mock.transfer(TOKEN_ID, owner.address);
-            expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
-        });
-
-        it('exposes the owner epoch and advances it on observed transfers', async function () {
-            expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(0);
-            await bap578Mock.transfer(TOKEN_ID, stranger.address);
-            // View call already reflects the pending change.
-            expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(1);
-            await vpm.connect(stranger).syncOwner(TOKEN_ID);
-            expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(1);
-        });
+    it('lets the NFT owner revoke', async function () {
+      await expect(
+        vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, operator.address),
+      ).to.emit(vpm, 'PermissionRevoked');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
     });
+
+    it('rejects revoking a grant that does not exist', async function () {
+      await expect(
+        vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, stranger.address),
+      ).to.be.revertedWith('VPM: no such grant');
+    });
+  });
+
+  describe('forwardHandleAction', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+    });
+
+    it('forwards to the bound logic when caller has WRITE', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      const data = ethers.utils.defaultAbiCoder.encode(['uint256'], [42]);
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', data),
+      ).to.emit(vpm, 'ActionForwarded');
+
+      expect(await logic.lastTokenId()).to.equal(TOKEN_ID);
+      expect(await logic.lastAction()).to.equal('buy_token');
+      expect(await logic.lastCaller()).to.equal(vpm.address);
+    });
+
+    it('lets an ADMIN-tier grantee call forwardHandleAction (ADMIN includes WRITE)', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, admin.address, ADMIN, 0, '');
+      await vpm.connect(admin).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x');
+      expect(await logic.lastTokenId()).to.equal(TOKEN_ID);
+      expect(await logic.lastAction()).to.equal('buy_token');
+    });
+
+    it('reverts when caller has no grant', async function () {
+      await expect(
+        vpm.connect(stranger).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+      ).to.be.revertedWith('VPM: caller lacks WRITE');
+    });
+
+    it('reverts when caller has only READ', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, READ, 0, '');
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+      ).to.be.revertedWith('VPM: caller lacks WRITE');
+    });
+
+    it('reverts when the grant has expired', async function () {
+      const expiry = (await ethers.provider.getBlock('latest')).timestamp + 30;
+      await vpm
+        .connect(owner)
+        .grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, expiry, '');
+      await ethers.provider.send('evm_increaseTime', [60]);
+      await ethers.provider.send('evm_mine');
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+      ).to.be.revertedWith('VPM: caller lacks WRITE');
+    });
+
+    it('reverts when no logic is bound', async function () {
+      await bap578Mock.setLogic(TOKEN_ID, ethers.constants.AddressZero);
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+      ).to.be.revertedWith('VPM: no logic bound');
+    });
+
+    it('bubbles up the logic module revert reason', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      await logic.setRevertNext(true, 'logic: insufficient balance');
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+      ).to.be.revertedWith('logic: insufficient balance');
+    });
+  });
+
+  describe('isolation between grants', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+    });
+
+    it('keeps two grantees independent on the same vault', async function () {
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, admin.address, READ, 0, '');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, admin.address)).to.equal(false);
+
+      await vpm.connect(owner).revokePermission(TOKEN_ID, VAULT_ID, operator.address);
+      // Revoking operator should not touch admin's grant.
+      const [adminOk] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, admin.address, READ);
+      expect(adminOk).to.equal(true);
+    });
+
+    it('isolates grants across vaults on the same token', async function () {
+      const OTHER = 'social';
+      await vpm.connect(owner).createVault(TOKEN_ID, OTHER, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+      expect(await vpm.canForward(TOKEN_ID, OTHER, operator.address)).to.equal(false);
+    });
+
+    it('isolates grants across tokens', async function () {
+      await bap578Mock.mint(2, owner.address, logic.address);
+      await vpm.connect(owner).createVault(2, VAULT_ID, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+      expect(await vpm.canForward(2, VAULT_ID, operator.address)).to.equal(false);
+    });
+  });
+
+  describe('re-grant semantics', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, READ, 0, '');
+    });
+
+    it('overwrites an existing grant with a new tier', async function () {
+      // Bump from READ to ADMIN by re-granting.
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, ADMIN, 0, '');
+      const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, ADMIN);
+      expect(ok).to.equal(true);
+    });
+
+    it('re-grants cleanly after the NFT changed hands', async function () {
+      await bap578Mock.transfer(TOKEN_ID, stranger.address);
+      // Old (auto-revoked) READ grant is replaced by a fresh WRITE under the new owner.
+      await vpm
+        .connect(stranger)
+        .grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+    });
+  });
+
+  describe('input validation', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+    });
+
+    it('rejects zero-address grantee', async function () {
+      await expect(
+        vpm
+          .connect(owner)
+          .grantPermission(TOKEN_ID, VAULT_ID, ethers.constants.AddressZero, WRITE, 0, ''),
+      ).to.be.revertedWith('VPM: grantee zero');
+    });
+
+    it('rejects grants on a non-existent vault', async function () {
+      await expect(
+        vpm.connect(owner).grantPermission(TOKEN_ID, 'ghost', operator.address, WRITE, 0, ''),
+      ).to.be.revertedWith('VPM: no such vault');
+    });
+
+    it('rejects forwards on a non-existent vault', async function () {
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, 'ghost', 'buy_token', '0x'),
+      ).to.be.revertedWith('VPM: no such vault');
+    });
+  });
+
+  describe('initialization + upgrade auth', function () {
+    it('rejects a second initialize', async function () {
+      await expect(vpm.initialize(bap578Mock.address)).to.be.reverted;
+    });
+
+    it('only the owner can authorize an upgrade', async function () {
+      const VPM = await ethers.getContractFactory('VaultPermissionManagerReference');
+      // Stranger attempting upgrade should revert.
+      const newImpl = await VPM.deploy();
+      await newImpl.deployed();
+      // The OwnableUpgradeable owner is the deployer of the proxy (this test runner).
+      // We simulate a non-owner upgrade attempt via the raw upgradeTo selector.
+      const ifaceFragment = ['function upgradeTo(address)'];
+      const proxyAsUUPS = new ethers.Contract(vpm.address, ifaceFragment, stranger);
+      await expect(proxyAsUUPS.upgradeTo(newImpl.address)).to.be.reverted;
+    });
+  });
+
+  describe('forwardHandleAction return value', function () {
+    it('returns whatever bytes the logic module returns', async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+      // Static-call to read the return value (mock returns abi.encode(true)).
+      const result = await vpm
+        .connect(operator)
+        .callStatic.forwardHandleAction(TOKEN_ID, VAULT_ID, 'check_balance', '0x');
+      const [decoded] = ethers.utils.defaultAbiCoder.decode(['bool'], result);
+      expect(decoded).to.equal(true);
+    });
+  });
+
+  describe('auto-revoke on NFT transfer', function () {
+    beforeEach(async function () {
+      await vpm.connect(owner).createVault(TOKEN_ID, VAULT_ID, '');
+      await vpm.connect(owner).grantPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE, 0, '');
+    });
+
+    it('invalidates the grant the moment the NFT changes hands', async function () {
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+      await bap578Mock.transfer(TOKEN_ID, stranger.address);
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+
+      const [ok] = await vpm.checkPermission(TOKEN_ID, VAULT_ID, operator.address, WRITE);
+      expect(ok).to.equal(false);
+
+      await expect(
+        vpm.connect(operator).forwardHandleAction(TOKEN_ID, VAULT_ID, 'buy_token', '0x'),
+      ).to.be.revertedWith('VPM: caller lacks WRITE');
+    });
+
+    it('lets the new owner issue their own grants on the existing vault', async function () {
+      await bap578Mock.transfer(TOKEN_ID, stranger.address);
+      // Old grant is invalid; new owner grants a fresh one.
+      await vpm
+        .connect(stranger)
+        .grantPermission(TOKEN_ID, VAULT_ID, admin.address, WRITE, 0, 'new owner bot');
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, admin.address)).to.equal(true);
+      // Old operator stays revoked.
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+    });
+
+    it('does NOT reactivate when the contract observed the intermediate owner', async function () {
+      await bap578Mock.transfer(TOKEN_ID, stranger.address);
+      // Anyone (here the new owner) commits the owner change, advancing the epoch.
+      await vpm.connect(stranger).syncOwner(TOKEN_ID);
+      await bap578Mock.transfer(TOKEN_ID, owner.address);
+      // The grant was stamped at epoch 0; the epoch is now 2, so it stays dead.
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+    });
+
+    // Documented residual edge case: if the NFT round-trips owners with NO
+    // VPM call at all in between, the contract never observed the change, so
+    // the epoch never advanced and the original grant reactivates. Closing
+    // this fully needs a transfer hook on BAP-578; an off-chain indexer
+    // calling syncOwner on Transfer events also closes it in practice.
+    it('residual: reactivates only on a fully unobserved owner round-trip', async function () {
+      await bap578Mock.transfer(TOKEN_ID, stranger.address);
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(false);
+      await bap578Mock.transfer(TOKEN_ID, owner.address);
+      expect(await vpm.canForward(TOKEN_ID, VAULT_ID, operator.address)).to.equal(true);
+    });
+
+    it('exposes the owner epoch and advances it on observed transfers', async function () {
+      expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(0);
+      await bap578Mock.transfer(TOKEN_ID, stranger.address);
+      // View call already reflects the pending change.
+      expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(1);
+      await vpm.connect(stranger).syncOwner(TOKEN_ID);
+      expect(await vpm.ownerEpoch(TOKEN_ID)).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
The `VaultPermissionManager` extension lets a BAP-578 NFT owner grant a third-party operator the right to drive their agent's `handleAction` entry point, within a time-bounded permission tier. The operator never holds the NFT and cannot transfer, list, or re-logic it.

It complements the existing `IPolicyGuard` framework. `IPolicyGuard` answers "is this action allowed?" (per-call). `IVaultPermissionManager` answers "is this actor authorized to drive the agent at all?" (per-actor). A full agent stack uses both.

### Ticket

N/A

#### Summary of Changes

Adds an interface, a UUPS reference implementation, two test mocks, and 30 tests, in the style of the existing `extensions/IPolicy*` family.

- `contracts/extensions/IVaultPermissionManager.sol`: interface. `PermissionLevel` tiers (NONE/READ/WRITE/ADMIN), `createVault`, `grantPermission`, `revokePermission`, `forwardHandleAction`, `checkPermission`, `canForward`, `vaultExists`.
- `contracts/extensions/VaultPermissionManagerReference.sol`: UUPS reference implementation. Per-agent vault namespaces, time-bounded grants, owner-or-admin grant authority, `nonReentrant` forwarding, and auto-revoke on NFT transfer (a grant stamps `ownerOf(tokenId)` at creation and is treated as revoked once the NFT changes hands).
- `contracts/mocks/MockBAP578ForVPM.sol`, `contracts/mocks/MockLogicModule.sol`: minimal mocks for the unit tests.
- `test/VaultPermissionManager.test.js`: 30 tests covering vault lifecycle, grant/revoke including the admin path, the forward path, cross-grantee/vault/token isolation, re-grant semantics, init plus upgrade auth, and auto-revoke including the documented transfer-and-back edge case.

Targets `pragma solidity ^0.8.28` and `@openzeppelin/contracts-upgradeable@^4.9.x` to match the repo. All 30 tests pass under the repo toolchain with no compiler warnings.

#### Notes

Composition with `IPolicyGuard`:

1. External caller invokes `VPM.forwardHandleAction(tokenId, vaultId, action, data)`.
2. VPM checks `canForward` (WRITE grant, not expired).
3. VPM dispatches into the bound logic module's `handleAction`.
4. The logic module gates its own outbound calls through `IPolicyGuard.validate(...)`.
5. After a successful action, the logic calls `IPolicyGuard.commit(...)`.

A logic module that wants to be drivable through VPM only needs the existing `handleAction` shape, with no new interface on its side.

Documented edge case: if an NFT returns to the original granter without an explicit revoke in between, stale grants reactivate (the `ownerAtGrant` stamp matches again). The test `reactivates a stale grant if the NFT returns to the original granter` covers it. A future minor version could swap the address stamp for a monotonic transfer counter to make invalidation permanent.

A deployed version of this design runs on BSC mainnet (`0x0fA3F984F7999d31C28055260637D1bCEA34919A`, UUPS, BscScan-verified). The reference implementation here is stripped of project-specific naming and dependencies.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

#### Checklist

- [x] Added tests
- [ ] Created showcase
